### PR TITLE
docs: fix reconnect comment and signer example

### DIFF
--- a/barter-data/src/streams/reconnect/mod.rs
+++ b/barter-data/src/streams/reconnect/mod.rs
@@ -6,7 +6,7 @@ pub mod stream;
 /// `Stream` is currently reconnecting.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub enum Event<Origin, T> {
-    /// [`ReconnectingStream`](stream::ReconnectingStream) has disconnecting and is
+    /// [`ReconnectingStream`](stream::ReconnectingStream) has disconnected and is
     /// attempting to reconnect.
     Reconnecting(Origin),
     Item(T),

--- a/barter-integration/README.md
+++ b/barter-integration/README.md
@@ -78,7 +78,6 @@ use barter_integration::{
         HttpParser,
     },
 };
-use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use reqwest::{RequestBuilder, StatusCode};
@@ -117,7 +116,7 @@ impl Signer for FtxSigner {
         })
     }
 
-    fn add_bytes_to_sign<M>(mac: &mut M, config: &Self::Config<'a>) -> Bytes
+    fn add_bytes_to_sign<M>(mac: &mut M, config: &Self::Config<'a>)
     where
         M: Mac
     {


### PR DESCRIPTION
## Summary
- improve reconnect message comment in `reconnect::Event`
- update signer example in `barter-integration` README to match implementation

## Testing
- `cargo test` *(fails: could not download crates)*