### PR TITLE
Replace Barter brand with Jackbot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "Barter CI"
+name: "Jackbot CI"
 
 on:
   push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.dependencies]
-# Barter Ecosystem
+# Jackbot Ecosystem
 barter-integration = { path = "./barter-integration", version = "0.9.1" }
 barter-instrument = { path = "./barter-instrument", version = "0.3.1" }
 barter-data = { path = "./barter-data", version = "0.10.1" }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Barter Ecosystem Contributors
+Copyright (c) 2024 Jackbot Ecosystem Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Jackbot Sensor
-Based on Barter is an algorithmic trading ecosystem of Rust libraries for building high-performance live-trading, paper-trading 
+Based on Jackbot is an algorithmic trading ecosystem of Rust libraries for building high-performance live-trading, paper-trading 
 and back-testing systems.
 * **Fast**: Written in native Rust. Minimal allocations. Data-oriented state management system with direct index lookups.
 * **Robust**: Strongly typed. Thread safe. Extensive test coverage.
 * **Customisable**: Plug and play Strategy and RiskManager components that facilitates most trading strategies (MarketMaking, StatArb, HFT, etc.).
 * **Scalable**: Multithreaded architecture with modular design. Leverages Tokio for I/O. Memory efficient data structures.  
 
-I expands Barter to support the exchanges of the Jackbot Terminal project:
-* Binance (Great reference implementation on Barter)
+I expands Jackbot to support the exchanges of the Jackbot Terminal project:
+* Binance (Great reference implementation on Jackbot)
 * Bitget
 * Bybit 
 * Coinbase
@@ -18,15 +18,15 @@ I expands Barter to support the exchanges of the Jackbot Terminal project:
 ## Overview
 Jackbot Sensor is an algorithmic trading ecosystem of Rust libraries for building high-performance live-trading, paper-trading 
 and back-testing systems. It is made up of several easy-to-use, extensible crates:
-* **Barter**: Algorithmic trading Engine with feature rich state management system.
-* **Barter-Instrument**: Exchange, Instrument and Asset data structures and utilities. 
-* **Barter-Data**: Stream public market data from financial venues. Easily extensible via the MarketStream interface.
-* **Barter-Execution**: Stream private account data and execute orders. Easily extensible via the ExecutionClient interface. 
-* **Barter-Integration**: Low-level frameworks for flexible REST/WebSocket integrations.
+* **Jackbot**: Algorithmic trading Engine with feature rich state management system.
+* **Jackbot-Instrument**: Exchange, Instrument and Asset data structures and utilities. 
+* **Jackbot-Data**: Stream public market data from financial venues. Easily extensible via the MarketStream interface.
+* **Jackbot-Execution**: Stream private account data and execute orders. Easily extensible via the ExecutionClient interface. 
+* **Jackbot-Integration**: Low-level frameworks for flexible REST/WebSocket integrations.
 
 ## Notable Features
-- Stream public market data from financial venues via the [`Barter-Data`] library. 
-- Stream private account data, execute orders (live or mock)** via the [`Barter-Execution`] library.
+- Stream public market data from financial venues via the [`Jackbot-Data`] library. 
+- Stream private account data, execute orders (live or mock)** via the [`Jackbot-Execution`] library.
 - Plug and play Strategy and RiskManager components that facilitate most trading strategies. 
 - Flexible Engine that facilitates trading strategies that execute on many exchanges simultaneously.
 - Use mock MarketStream or Execution components to enable back-testing on a near-identical trading system as live-trading.  

--- a/barter-data/Cargo.toml
+++ b/barter-data/Cargo.toml
@@ -16,7 +16,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 rust_decimal_macros = { workspace = true }
 
 [dependencies]
-# Barter Ecosystem
+# Jackbot Ecosystem
 barter-integration = { workspace = true }
 barter-instrument = { workspace = true }
 barter-macro = { workspace = true }

--- a/barter-data/LICENSE
+++ b/barter-data/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Barter-Data Contributors
+Copyright (c) 2021 Jackbot-Data Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/barter-data/README.md
+++ b/barter-data/README.md
@@ -1,14 +1,14 @@
 
-# Barter-Data
+# Jackbot-Data
 A high-performance WebSocket integration library for streaming public market data from leading cryptocurrency 
 exchanges - batteries included. It is:
-* **Easy**: Barter-Data's simple StreamBuilder interface allows for easy & quick setup (see example below!).
-* **Normalised**: Barter-Data's unified interface for consuming public WebSocket data means every Exchange returns a normalised data model.
-* **Real-Time**: Barter-Data utilises real-time WebSocket integrations enabling the consumption of normalised tick-by-tick data.
-* **Extensible**: Barter-Data is highly extensible, and therefore easy to contribute to with coding new integrations!
+* **Easy**: Jackbot-Data's simple StreamBuilder interface allows for easy & quick setup (see example below!).
+* **Normalised**: Jackbot-Data's unified interface for consuming public WebSocket data means every Exchange returns a normalised data model.
+* **Real-Time**: Jackbot-Data utilises real-time WebSocket integrations enabling the consumption of normalised tick-by-tick data.
+* **Extensible**: Jackbot-Data is highly extensible, and therefore easy to contribute to with coding new integrations!
 
-**See: [`Barter`], [`Barter-Instrument`], [`Barter-Execution`] & [`Barter-Integration`] for
-comprehensive documentation of other Barter libraries.**
+**See: [`Jackbot`], [`Jackbot-Instrument`], [`Jackbot-Execution`] & [`Jackbot-Integration`] for
+comprehensive documentation of other Jackbot libraries.**
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -26,20 +26,20 @@ comprehensive documentation of other Barter libraries.**
 [API Documentation] |
 [Chat]
 
-[`Barter`]: https://crates.io/crates/barter
-[`Barter-Instrument`]: https://crates.io/crates/barter-instrument
-[`Barter-Execution`]: https://crates.io/crates/barter-execution
-[`Barter-Integration`]: https://crates.io/crates/barter-integration
+[`Jackbot`]: https://crates.io/crates/barter
+[`Jackbot-Instrument`]: https://crates.io/crates/barter-instrument
+[`Jackbot-Execution`]: https://crates.io/crates/barter-execution
+[`Jackbot-Integration`]: https://crates.io/crates/barter-integration
 [API Documentation]: https://docs.rs/barter-data/latest/barter_data
 [Chat]: https://discord.gg/wE7RqhnQMV
 
 ## Overview
-Barter-Data is a high-performance WebSocket integration library for streaming public market data from leading cryptocurrency 
+Jackbot-Data is a high-performance WebSocket integration library for streaming public market data from leading cryptocurrency 
 exchanges. It presents an easy-to-use and extensible set of interfaces that can deliver normalised exchange data in real-time.
 
 From a user perspective, the major component is the `StreamBuilder` structures that assists in initialising an 
 arbitrary number of exchange `MarketStream`s using input `Subscription`s. Simply build your dream set of 
-`MarketStreams` and `Barter-Data` will do the rest!
+`MarketStreams` and `Jackbot-Data` will do the rest!
 
 ### Supported Exchange Subscriptions
 
@@ -154,17 +154,17 @@ async fn main() {
 Firstly, see if the answer to your question can be found in the [API Documentation]. If the answer is not there, I'd be happy to help via [Chat] <br>
 and try answer your question via Discord.
 
-## Support Barter Development
-Help us advance Barter's capabilities by becoming a sponsor (or supporting me with a tip!).
+## Support Jackbot Development
+Help us advance Jackbot's capabilities by becoming a sponsor (or supporting me with a tip!).
 
-Your contribution will allow me to dedicate more time to Barter, accelerating feature development and improvements.
+Your contribution will allow me to dedicate more time to Jackbot, accelerating feature development and improvements.
 
 **Please email *justastream.code@gmail.com* for all inquiries**
 
 Please see [here](../README.md#support-barter-development) for more information.
 
 ## Contributing
-Thanks in advance for helping to develop the Barter ecosystem! Please do get hesitate to get touch via the Discord 
+Thanks in advance for helping to develop the Jackbot ecosystem! Please do get hesitate to get touch via the Discord 
 [Chat] to discuss development, new features, and the future roadmap.
 
 ### Adding A New Exchange Connector
@@ -186,7 +186,7 @@ This project is licensed under the [MIT license].
 
 ### Contribution License Agreement
 
-Any contribution you intentionally submit for inclusion in Barter workspace crates shall be:
+Any contribution you intentionally submit for inclusion in Jackbot workspace crates shall be:
 1. Licensed under MIT
 2. Subject to all disclaimers and limitations of liability stated below
 3. Provided without any additional terms or conditions

--- a/barter-data/src/books/mod.rs
+++ b/barter-data/src/books/mod.rs
@@ -13,7 +13,7 @@ pub mod manager;
 /// Provides an abstract collection of cheaply cloneable shared-state [`OrderBook`].
 pub mod map;
 
-/// Normalised Barter [`OrderBook`] snapshot.
+/// Normalised Jackbot [`OrderBook`] snapshot.
 #[derive(Clone, PartialEq, Eq, Debug, Default, Deserialize, Serialize)]
 pub struct OrderBook {
     pub sequence: u64,
@@ -118,7 +118,7 @@ impl OrderBook {
     }
 }
 
-/// Normalised Barter [`Level`]s for one `Side` ( of the [`OrderBook`].
+/// Normalised Jackbot [`Level`]s for one `Side` ( of the [`OrderBook`].
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct OrderBookSide<Side> {
     #[serde(skip_serializing)]
@@ -265,7 +265,7 @@ impl Default for OrderBookSide<Asks> {
     }
 }
 
-/// Normalised Barter OrderBook [`Level`].
+/// Normalised Jackbot OrderBook [`Level`].
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize)]
 pub struct Level {
     pub price: Decimal,

--- a/barter-data/src/event.rs
+++ b/barter-data/src/event.rs
@@ -28,11 +28,11 @@ impl<InstrumentKey, T> FromIterator<Result<MarketEvent<InstrumentKey, T>, DataEr
     }
 }
 
-/// Normalised Barter [`MarketEvent<T>`](Self) wrapping the `T` data variant in metadata.
+/// Normalised Jackbot [`MarketEvent<T>`](Self) wrapping the `T` data variant in metadata.
 ///
 /// Note: `T` can be an enum such as the [`DataKind`] if required.
 ///
-/// See [`crate::subscription`] for all existing Barter Market event variants.
+/// See [`crate::subscription`] for all existing Jackbot Market event variants.
 ///
 /// ### Examples
 /// - [`MarketEvent<PublicTrade>`](PublicTrade)
@@ -109,7 +109,7 @@ impl<InstrumentKey> MarketEvent<InstrumentKey, DataKind> {
     }
 }
 
-/// Available kinds of normalised Barter [`MarketEvent<T>`](MarketEvent).
+/// Available kinds of normalised Jackbot [`MarketEvent<T>`](MarketEvent).
 ///
 /// ### Notes
 /// - [`Self`] is only used as the [`MarketEvent<DataKind>`](MarketEvent) `Output` when combining

--- a/barter-data/src/exchange/binance/channel.rs
+++ b/barter-data/src/exchange/binance/channel.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use serde::Serialize;
 
-/// Type that defines how to translate a Barter [`Subscription`] into a [`Binance`]
+/// Type that defines how to translate a Jackbot [`Subscription`] into a [`Binance`]
 /// channel to be subscribed to.
 ///
 /// See docs: <https://binance-docs.github.io/apidocs/spot/en/#websocket-market-streams>

--- a/barter-data/src/exchange/binance/market.rs
+++ b/barter-data/src/exchange/binance/market.rs
@@ -6,7 +6,7 @@ use barter_instrument::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, StrExt, format_smolstr};
 
-/// Type that defines how to translate a Barter [`Subscription`] into a [`Binance`]
+/// Type that defines how to translate a Jackbot [`Subscription`] into a [`Binance`]
 /// market that can be subscribed to.
 ///
 /// See docs: <https://binance-docs.github.io/apidocs/spot/en/#websocket-market-streams>

--- a/barter-data/src/exchange/binance/mod.rs
+++ b/barter-data/src/exchange/binance/mod.rs
@@ -19,7 +19,7 @@ use url::Url;
 /// [`BinanceFuturesUsd`](futures::BinanceFuturesUsd).
 pub mod book;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific channel used for generating [`Connector::requests`].
 pub mod channel;
 
@@ -27,7 +27,7 @@ pub mod channel;
 /// [`BinanceFuturesUsd`](futures::BinanceFuturesUsd).
 pub mod futures;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific market used for generating [`Connector::requests`].
 pub mod market;
 

--- a/barter-data/src/exchange/binance/trade.rs
+++ b/barter-data/src/exchange/binance/trade.rs
@@ -105,7 +105,7 @@ where
         .map(|market| ExchangeSub::from((BinanceChannel::TRADES, market)).id())
 }
 
-/// Deserialize a [`BinanceTrade`] "buyer_is_maker" boolean field to a Barter [`Side`].
+/// Deserialize a [`BinanceTrade`] "buyer_is_maker" boolean field to a Jackbot [`Side`].
 ///
 /// Variants:
 /// buyer_is_maker => Side::Sell

--- a/barter-data/src/exchange/bitfinex/channel.rs
+++ b/barter-data/src/exchange/bitfinex/channel.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use serde::Serialize;
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Bitfinex`] channel to be subscribed to.
 ///
 /// See docs: <https://docs.bitfinex.com/docs/ws-public>

--- a/barter-data/src/exchange/bitfinex/market.rs
+++ b/barter-data/src/exchange/bitfinex/market.rs
@@ -6,7 +6,7 @@ use barter_instrument::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, ToSmolStr, format_smolstr};
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Bitfinex`] market that can be subscribed to.
 ///
 /// See docs: <https://docs.bitfinex.com/docs/ws-public>

--- a/barter-data/src/exchange/bitfinex/mod.rs
+++ b/barter-data/src/exchange/bitfinex/mod.rs
@@ -38,11 +38,11 @@ use derive_more::Display;
 use serde_json::json;
 use url::Url;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific channel used for generating [`Connector::requests`].
 pub mod channel;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific market used for generating [`Connector::requests`].
 pub mod market;
 

--- a/barter-data/src/exchange/bitmex/channel.rs
+++ b/barter-data/src/exchange/bitmex/channel.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use serde::Serialize;
 
-/// Type that defines how to translate a Barter [`Subscription`] into a [`Bitmex`]
+/// Type that defines how to translate a Jackbot [`Subscription`] into a [`Bitmex`]
 /// channel to be subscribed to.
 ///
 /// See docs: <https://www.bitmex.com/app/wsAPI>

--- a/barter-data/src/exchange/bitmex/market.rs
+++ b/barter-data/src/exchange/bitmex/market.rs
@@ -8,7 +8,7 @@ use barter_instrument::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, StrExt, format_smolstr};
 
-/// Type that defines how to translate a Barter [`Subscription`] into a [`Bitmex`]
+/// Type that defines how to translate a Jackbot [`Subscription`] into a [`Bitmex`]
 /// market that can be subscribed to.
 ///
 /// See docs: <https://www.bitmex.com/app/wsAPI>

--- a/barter-data/src/exchange/bitmex/mod.rs
+++ b/barter-data/src/exchange/bitmex/mod.rs
@@ -20,11 +20,11 @@ use serde::de::{Error, Unexpected};
 use std::fmt::Debug;
 use url::Url;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific channel used for generating [`Connector::requests`].
 pub mod channel;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific market used for generating [`Connector::requests`].
 pub mod market;
 

--- a/barter-data/src/exchange/bybit/channel.rs
+++ b/barter-data/src/exchange/bybit/channel.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use serde::Serialize;
 
-/// Type that defines how to translate a Barter [`Subscription`] into a [`Bybit`]
+/// Type that defines how to translate a Jackbot [`Subscription`] into a [`Bybit`]
 /// channel to be subscribed to.
 ///
 /// See docs: <https://bybit-exchange.github.io/docs/v5/ws/connect>

--- a/barter-data/src/exchange/bybit/market.rs
+++ b/barter-data/src/exchange/bybit/market.rs
@@ -8,7 +8,7 @@ use barter_instrument::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, StrExt, format_smolstr};
 
-/// Type that defines how to translate a Barter [`Subscription`] into a [`Bybit`]
+/// Type that defines how to translate a Jackbot [`Subscription`] into a [`Bybit`]
 /// market that can be subscribed to.
 ///
 /// See docs: <https://bybit-exchange.github.io/docs/v5/ws/connect>

--- a/barter-data/src/exchange/bybit/mod.rs
+++ b/barter-data/src/exchange/bybit/mod.rs
@@ -20,7 +20,7 @@ use std::{fmt::Debug, marker::PhantomData, time::Duration};
 use tokio::time;
 use url::Url;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific channel used for generating [`Connector::requests`].
 pub mod channel;
 
@@ -28,7 +28,7 @@ pub mod channel;
 /// [`BybitFuturesUsd`](futures::BybitPerpetualsUsd).
 pub mod futures;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific market used for generating [`Connector::requests`].
 pub mod market;
 

--- a/barter-data/src/exchange/coinbase/channel.rs
+++ b/barter-data/src/exchange/coinbase/channel.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use serde::Serialize;
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Coinbase`] channel to be subscribed to.
 ///
 /// See docs: <https://docs.cloud.coinbase.com/exchange/docs/websocket-overview#subscribe>

--- a/barter-data/src/exchange/coinbase/market.rs
+++ b/barter-data/src/exchange/coinbase/market.rs
@@ -6,7 +6,7 @@ use barter_instrument::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, StrExt, format_smolstr};
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Coinbase`] market that can be subscribed to.
 ///
 /// See docs: <https://docs.cloud.coinbase.com/exchange/docs/websocket-overview#subscribe>

--- a/barter-data/src/exchange/coinbase/mod.rs
+++ b/barter-data/src/exchange/coinbase/mod.rs
@@ -17,11 +17,11 @@ use derive_more::Display;
 use serde_json::json;
 use url::Url;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific channel used for generating [`Connector::requests`].
 pub mod channel;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific market used for generating [`Connector::requests`].
 pub mod market;
 

--- a/barter-data/src/exchange/gateio/channel.rs
+++ b/barter-data/src/exchange/gateio/channel.rs
@@ -6,7 +6,7 @@ use crate::{
 use barter_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
 use serde::Serialize;
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Gateio`](super::Gateio) channel to be subscribed to.
 ///
 /// See docs: <https://www.okx.com/docs-v5/en/#websocket-api-public-channel>

--- a/barter-data/src/exchange/gateio/market.rs
+++ b/barter-data/src/exchange/gateio/market.rs
@@ -14,7 +14,7 @@ use chrono::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, StrExt, format_smolstr};
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Gateio`] market that can be subscribed to.
 ///
 /// See docs: <https://www.okx.com/docs-v5/en/#websocket-api-public-channel>

--- a/barter-data/src/exchange/gateio/mod.rs
+++ b/barter-data/src/exchange/gateio/mod.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use std::{fmt::Debug, marker::PhantomData};
 use url::Url;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific channel used for generating [`Connector::requests`].
 pub mod channel;
 
@@ -31,7 +31,7 @@ pub mod perpetual;
 /// [`GateioOptions`](option::GateioOptions)
 pub mod option;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific market used for generating [`Connector::requests`].
 pub mod market;
 

--- a/barter-data/src/exchange/kraken/channel.rs
+++ b/barter-data/src/exchange/kraken/channel.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use serde::Serialize;
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Kraken`] channel to be subscribed to.
 ///
 /// See docs: <https://docs.kraken.com/websockets/#message-subscribe>

--- a/barter-data/src/exchange/kraken/market.rs
+++ b/barter-data/src/exchange/kraken/market.rs
@@ -6,7 +6,7 @@ use barter_instrument::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, StrExt, format_smolstr};
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Kraken`] market that can be subscribed to.
 ///
 /// See docs: <https://docs.kraken.com/websockets/#message-subscribe>

--- a/barter-data/src/exchange/kraken/mod.rs
+++ b/barter-data/src/exchange/kraken/mod.rs
@@ -20,11 +20,11 @@ use url::Url;
 /// OrderBook types for [`Kraken`].
 pub mod book;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific channel used for generating [`Connector::requests`].
 pub mod channel;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`]  specific market used for generating [`Connector::requests`].
 pub mod market;
 

--- a/barter-data/src/exchange/mod.rs
+++ b/barter-data/src/exchange/mod.rs
@@ -60,7 +60,7 @@ where
     type Stream: MarketStream<Self, Instrument, Kind>;
 }
 
-/// Primary exchange abstraction. Defines how to translate Barter types into exchange specific
+/// Primary exchange abstraction. Defines how to translate Jackbot types into exchange specific
 /// types, as well as connecting, subscribing, and interacting with the exchange server.
 ///
 /// ### Notes
@@ -72,7 +72,7 @@ where
     /// Unique identifier for the exchange server being connected with.
     const ID: ExchangeId;
 
-    /// Type that defines how to translate a Barter `Subscription` into an exchange specific
+    /// Type that defines how to translate a Jackbot `Subscription` into an exchange specific
     /// channel to be subscribed to.
     ///
     /// ### Examples
@@ -80,7 +80,7 @@ where
     /// - [`KrakenChannel("trade")`](kraken::channel::KrakenChannel)
     type Channel: AsRef<str>;
 
-    /// Type that defines how to translate a Barter
+    /// Type that defines how to translate a Jackbot
     /// `Subscription` into an exchange specific market that
     /// can be subscribed to.
     ///

--- a/barter-data/src/exchange/okx/channel.rs
+++ b/barter-data/src/exchange/okx/channel.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use serde::Serialize;
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Okx`] channel to be subscribed to.
 ///
 /// See docs: <https://www.okx.com/docs-v5/en/#websocket-api-public-channel>

--- a/barter-data/src/exchange/okx/market.rs
+++ b/barter-data/src/exchange/okx/market.rs
@@ -14,7 +14,7 @@ use chrono::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, StrExt, format_smolstr};
 
-/// Type that defines how to translate a Barter [`Subscription`] into a
+/// Type that defines how to translate a Jackbot [`Subscription`] into a
 /// [`Okx`] market that can be subscribed to.
 ///
 /// See docs: <https://www.okx.com/docs-v5/en/#websocket-api-public-channel>

--- a/barter-data/src/exchange/okx/mod.rs
+++ b/barter-data/src/exchange/okx/mod.rs
@@ -17,11 +17,11 @@ use serde_json::json;
 use std::time::Duration;
 use url::Url;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific channel used for generating [`Connector::requests`].
 pub mod channel;
 
-/// Defines the type that translates a Barter [`Subscription`](crate::subscription::Subscription)
+/// Defines the type that translates a Jackbot [`Subscription`](crate::subscription::Subscription)
 /// into an execution [`Connector`] specific market used for generating [`Connector::requests`].
 pub mod market;
 

--- a/barter-data/src/exchange/okx/trade.rs
+++ b/barter-data/src/exchange/okx/trade.rs
@@ -117,7 +117,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, OkxTrades)>
     }
 }
 
-/// Deserialize an [`OkxMessage`] "arg" field as a Barter [`SubscriptionId`].
+/// Deserialize an [`OkxMessage`] "arg" field as a Jackbot [`SubscriptionId`].
 fn de_okx_message_arg_as_subscription_id<'de, D>(
     deserializer: D,
 ) -> Result<SubscriptionId, D::Error>

--- a/barter-data/src/exchange/subscription.rs
+++ b/barter-data/src/exchange/subscription.rs
@@ -24,7 +24,7 @@ use serde::Deserialize;
 /// ```
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
 pub struct ExchangeSub<Channel, Market> {
-    /// Type that defines how to translate a Barter [`Subscription`] into an exchange specific
+    /// Type that defines how to translate a Jackbot [`Subscription`] into an exchange specific
     /// channel to be subscribed to.
     ///
     /// ### Examples
@@ -32,7 +32,7 @@ pub struct ExchangeSub<Channel, Market> {
     /// - [`KrakenChannel("trade")`](super::kraken::channel::KrakenChannel)
     pub channel: Channel,
 
-    /// Type that defines how to translate a Barter [`Subscription`] into an exchange specific
+    /// Type that defines how to translate a Jackbot [`Subscription`] into an exchange specific
     /// market that can be subscribed to.
     ///
     /// ### Examples
@@ -60,7 +60,7 @@ where
     Channel: AsRef<str>,
     Market: AsRef<str>,
 {
-    /// Construct a new exchange specific [`Self`] with the Barter [`Subscription`] provided.
+    /// Construct a new exchange specific [`Self`] with the Jackbot [`Subscription`] provided.
     pub fn new<Exchange, Instrument, Kind>(sub: &Subscription<Exchange, Instrument, Kind>) -> Self
     where
         Subscription<Exchange, Instrument, Kind>: Identifier<Channel> + Identifier<Market>,

--- a/barter-data/src/lib.rs
+++ b/barter-data/src/lib.rs
@@ -12,13 +12,13 @@
 )]
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
-//! # Barter-Data
+//! # Jackbot-Data
 //! A high-performance WebSocket integration library for streaming public market data from leading cryptocurrency
 //! exchanges - batteries included. It is:
-//! * **Easy**: Barter-Data's simple [`StreamBuilder`](streams::builder::StreamBuilder) and [`DynamicStreams`](streams::builder::dynamic::DynamicStreams) interface allows for easy & quick setup (see example below and /examples!).
-//! * **Normalised**: Barter-Data's unified interface for consuming public WebSocket data means every Exchange returns a normalised data model.
-//! * **Real-Time**: Barter-Data utilises real-time WebSocket integrations enabling the consumption of normalised tick-by-tick data.
-//! * **Extensible**: Barter-Data is highly extensible, and therefore easy to contribute to with coding new integrations!
+//! * **Easy**: Jackbot-Data's simple [`StreamBuilder`](streams::builder::StreamBuilder) and [`DynamicStreams`](streams::builder::dynamic::DynamicStreams) interface allows for easy & quick setup (see example below and /examples!).
+//! * **Normalised**: Jackbot-Data's unified interface for consuming public WebSocket data means every Exchange returns a normalised data model.
+//! * **Real-Time**: Jackbot-Data utilises real-time WebSocket integrations enabling the consumption of normalised tick-by-tick data.
+//! * **Extensible**: Jackbot-Data is highly extensible, and therefore easy to contribute to with coding new integrations!
 //!
 //! ## User API
 //! - [`StreamBuilder`](streams::builder::StreamBuilder) for initialising [`MarketStream`]s of specific data kinds.
@@ -115,7 +115,7 @@ use std::{collections::VecDeque, future::Future};
 use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
 
-/// All [`Error`](std::error::Error)s generated in Barter-Data.
+/// All [`Error`](std::error::Error)s generated in Jackbot-Data.
 pub mod error;
 
 /// Defines the generic [`MarketEvent<T>`](MarketEvent) used in every [`MarketStream`].
@@ -125,7 +125,7 @@ pub mod event;
 pub mod exchange;
 
 /// High-level API types used for building [`MarketStream`]s from collections
-/// of Barter [`Subscription`]s.
+/// of Jackbot [`Subscription`]s.
 pub mod streams;
 
 /// [`Subscriber`], [`SubscriptionMapper`](subscriber::mapper::SubscriptionMapper) and
@@ -136,7 +136,7 @@ pub mod streams;
 pub mod subscriber;
 
 /// Types that communicate the type of each [`MarketStream`] to initialise, and what normalised
-/// Barter output type the exchange will be transformed into.
+/// Jackbot output type the exchange will be transformed into.
 pub mod subscription;
 
 /// [`InstrumentData`] trait for instrument describing data.
@@ -147,7 +147,7 @@ pub mod instrument;
 pub mod books;
 
 /// Generic [`ExchangeTransformer`] implementations used by [`MarketStream`]s to translate exchange
-/// specific types to normalised Barter types.
+/// specific types to normalised Jackbot types.
 ///
 /// A standard [`StatelessTransformer`](transformer::stateless::StatelessTransformer) implementation
 /// that works for most `Exchange`-`SubscriptionKind` combinations is included.

--- a/barter-data/src/subscriber/mapper.rs
+++ b/barter-data/src/subscriber/mapper.rs
@@ -8,7 +8,7 @@ use barter_integration::subscription::SubscriptionId;
 use fnv::FnvHashMap;
 use serde::{Deserialize, Serialize};
 
-/// Defines how to map a collection of Barter [`Subscription`]s into execution specific
+/// Defines how to map a collection of Jackbot [`Subscription`]s into execution specific
 /// [`SubscriptionMeta`], containing subscription payloads that are sent to the execution.
 pub trait SubscriptionMapper {
     fn map<Exchange, Instrument, Kind>(
@@ -45,17 +45,17 @@ impl SubscriptionMapper for WebSocketSubMapper {
             Default::default(),
         ));
 
-        // Map Barter Subscriptions to execution specific subscriptions
+        // Map Jackbot Subscriptions to execution specific subscriptions
         let exchange_subs = subscriptions
             .iter()
             .map(|subscription| {
-                // Translate Barter Subscription to execution specific subscription
+                // Translate Jackbot Subscription to execution specific subscription
                 let exchange_sub = ExchangeSub::new(subscription);
 
                 // Determine the SubscriptionId associated with this execution specific subscription
                 let subscription_id = exchange_sub.id();
 
-                // Use ExchangeSub SubscriptionId as the manager to this Barter Subscription
+                // Use ExchangeSub SubscriptionId as the manager to this Jackbot Subscription
                 instrument_map
                     .0
                     .insert(subscription_id, subscription.instrument.key().clone());

--- a/barter-data/src/subscriber/mod.rs
+++ b/barter-data/src/subscriber/mod.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 use tracing::debug;
 
 /// [`SubscriptionMapper`] implementations defining how to map a
-/// collection of Barter [`Subscription`]s into execution specific [`SubscriptionMeta`].
+/// collection of Jackbot [`Subscription`]s into execution specific [`SubscriptionMeta`].
 pub mod mapper;
 
 /// [`SubscriptionValidator`] implementations defining how to

--- a/barter-data/src/subscription/book.rs
+++ b/barter-data/src/subscription/book.rs
@@ -6,7 +6,7 @@ use derive_more::Constructor;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
-/// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`OrderBookL1`]
+/// Jackbot [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`OrderBookL1`]
 /// market events.
 ///
 /// Level 1 refers to the best non-aggregated bid and ask [`Level`] on each side of the
@@ -29,7 +29,7 @@ impl std::fmt::Display for OrderBooksL1 {
     }
 }
 
-/// Normalised Barter [`OrderBookL1`] snapshot containing the latest best bid and ask.
+/// Normalised Jackbot [`OrderBookL1`] snapshot containing the latest best bid and ask.
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize, Constructor,
 )]
@@ -62,7 +62,7 @@ impl OrderBookL1 {
     }
 }
 
-/// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields L2
+/// Jackbot [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields L2
 /// [`OrderBookEvent`] market events
 ///
 /// Level 2 refers to an [`OrderBook`] with orders at each price level aggregated.
@@ -84,7 +84,7 @@ impl std::fmt::Display for OrderBooksL2 {
     }
 }
 
-/// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields
+/// Jackbot [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields
 /// L3 [`OrderBookEvent`] market events.
 ///
 /// Level 3 refers to the non-aggregated [`OrderBook`]. This is a direct replication of the exchange

--- a/barter-data/src/subscription/candle.rs
+++ b/barter-data/src/subscription/candle.rs
@@ -2,7 +2,7 @@ use super::SubscriptionKind;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`Candle`]
+/// Jackbot [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`Candle`]
 /// [`MarketEvent<T>`](crate::event::MarketEvent) events.
 #[derive(
     Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Deserialize, Serialize,
@@ -23,7 +23,7 @@ impl std::fmt::Display for Candles {
     }
 }
 
-/// Normalised Barter OHLCV [`Candle`] model.
+/// Normalised Jackbot OHLCV [`Candle`] model.
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct Candle {
     pub close_time: DateTime<Utc>,

--- a/barter-data/src/subscription/liquidation.rs
+++ b/barter-data/src/subscription/liquidation.rs
@@ -3,7 +3,7 @@ use barter_instrument::Side;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`Liquidation`]
+/// Jackbot [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`Liquidation`]
 /// [`MarketEvent<T>`](crate::event::MarketEvent) events.
 #[derive(
     Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Deserialize, Serialize,
@@ -24,7 +24,7 @@ impl std::fmt::Display for Liquidations {
     }
 }
 
-/// Normalised Barter [`Liquidation`] model.
+/// Normalised Jackbot [`Liquidation`] model.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct Liquidation {
     pub side: Side,

--- a/barter-data/src/subscription/mod.rs
+++ b/barter-data/src/subscription/mod.rs
@@ -14,16 +14,16 @@ use serde::{Deserialize, Serialize};
 use smol_str::{ToSmolStr, format_smolstr};
 use std::{borrow::Borrow, fmt::Debug, hash::Hash};
 
-/// OrderBook [`SubscriptionKind`]s and the associated Barter output data models.
+/// OrderBook [`SubscriptionKind`]s and the associated Jackbot output data models.
 pub mod book;
 
-/// Candle [`SubscriptionKind`] and the associated Barter output data model.
+/// Candle [`SubscriptionKind`] and the associated Jackbot output data model.
 pub mod candle;
 
-/// Liquidation [`SubscriptionKind`] and the associated Barter output data model.
+/// Liquidation [`SubscriptionKind`] and the associated Jackbot output data model.
 pub mod liquidation;
 
-/// Public trade [`SubscriptionKind`] and the associated Barter output data model.
+/// Public trade [`SubscriptionKind`] and the associated Jackbot output data model.
 pub mod trade;
 
 /// Defines kind of a [`Subscription`], and the output [`Self::Event`] that it yields.
@@ -35,7 +35,7 @@ where
     fn as_str(&self) -> &'static str;
 }
 
-/// Barter [`Subscription`] used to subscribe to a [`SubscriptionKind`] for a particular execution
+/// Jackbot [`Subscription`] used to subscribe to a [`SubscriptionKind`] for a particular execution
 /// [`MarketDataInstrument`].
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 pub struct Subscription<Exchange = ExchangeId, Inst = MarketDataInstrument, Kind = SubKind> {
@@ -278,12 +278,12 @@ pub fn exchange_supports_instrument_kind_sub_kind(
     }
 }
 
-/// Metadata generated from a collection of Barter [`Subscription`]s, including the execution
+/// Metadata generated from a collection of Jackbot [`Subscription`]s, including the execution
 /// specific subscription payloads that are sent to the execution.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct SubscriptionMeta<InstrumentKey> {
     /// `HashMap` containing the mapping between a [`SubscriptionId`] and
-    /// it's associated Barter [`MarketDataInstrument`].
+    /// it's associated Jackbot [`MarketDataInstrument`].
     pub instrument_map: Map<InstrumentKey>,
     /// Collection of [`WsMessage`]s containing execution specific subscription payloads to be sent.
     pub ws_subscriptions: Vec<WsMessage>,
@@ -292,7 +292,7 @@ pub struct SubscriptionMeta<InstrumentKey> {
 /// New type`HashMap` that maps a [`SubscriptionId`] to some associated type `T`.
 ///
 /// Used by [`ExchangeTransformer`](crate::transformer::ExchangeTransformer)s to identify the
-/// Barter [`MarketDataInstrument`] associated with incoming execution messages.
+/// Jackbot [`MarketDataInstrument`] associated with incoming execution messages.
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct Map<T>(pub FnvHashMap<SubscriptionId, T>);
 

--- a/barter-data/src/subscription/trade.rs
+++ b/barter-data/src/subscription/trade.rs
@@ -3,7 +3,7 @@ use barter_instrument::Side;
 use barter_macro::{DeSubKind, SerSubKind};
 use serde::{Deserialize, Serialize};
 
-/// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`PublicTrade`]
+/// Jackbot [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`PublicTrade`]
 /// [`MarketEvent<T>`](crate::event::MarketEvent) events.
 #[derive(
     Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, DeSubKind, SerSubKind,
@@ -24,7 +24,7 @@ impl std::fmt::Display for PublicTrades {
     }
 }
 
-/// Normalised Barter [`PublicTrade`] model.
+/// Normalised Jackbot [`PublicTrade`] model.
 #[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct PublicTrade {
     pub id: String,

--- a/barter-data/src/transformer/mod.rs
+++ b/barter-data/src/transformer/mod.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc;
 pub mod stateless;
 
 /// Defines how to construct a [`Transformer`] used by [`MarketStream`](super::MarketStream)s to
-/// translate execution specific types to normalised Barter types.
+/// translate execution specific types to normalised Jackbot types.
 #[async_trait]
 pub trait ExchangeTransformer<Exchange, InstrumentKey, Kind>
 where

--- a/barter-data/src/transformer/stateless.rs
+++ b/barter-data/src/transformer/stateless.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 use tokio::sync::mpsc;
 
 /// Standard generic stateless [`ExchangeTransformer`] to translate execution specific types into
-/// normalised Barter types. Often used with
+/// normalised Jackbot types. Often used with
 /// [`PublicTrades`](crate::subscription::trade::PublicTrades) or
 /// [`OrderBooksL1`](crate::subscription::book::OrderBooksL1) streams.
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/barter-execution/Cargo.toml
+++ b/barter-execution/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["accessibility", "simulation"]
 
 
 [dependencies]
-# Barter Ecosystem
+# Jackbot Ecosystem
 barter-integration = { workspace = true }
 barter-instrument = { workspace = true }
 

--- a/barter-execution/LICENSE
+++ b/barter-execution/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Barter-Execution Contributors
+Copyright (c) 2022 Jackbot-Execution Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/barter-execution/README.md
+++ b/barter-execution/README.md
@@ -1,14 +1,14 @@
-# Barter-Execution
+# Jackbot-Execution
 Stream private account data from financial venues, and execute (live or mock) orders. Also provides
 a feature rich MockExchange and MockExecutionClient to assist with backtesting and paper-trading.
 
 **It is:**
 * **Easy**: ExecutionClient trait provides a unified and simple language for interacting with exchanges.
 * **Normalised**: Allow your strategy to communicate with every real or MockExchange using the same interface.
-* **Extensible**: Barter-Execution is highly extensible, making it easy to contribute by adding new exchange integrations!
+* **Extensible**: Jackbot-Execution is highly extensible, making it easy to contribute by adding new exchange integrations!
 
-**See: [`Barter`], [`Barter-Data`], [`Barter-Instrument`] & [`Barter-Integration`] for
-comprehensive documentation of other Barter libraries.**
+**See: [`Jackbot`], [`Jackbot-Data`], [`Jackbot-Instrument`] & [`Jackbot-Integration`] for
+comprehensive documentation of other Jackbot libraries.**
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -25,10 +25,10 @@ comprehensive documentation of other Barter libraries.**
 
 [API Documentation] | [Chat]
 
-[`Barter`]: https://crates.io/crates/barter
-[`Barter-Data`]: https://crates.io/crates/barter-data
-[`Barter-Instrument`]: https://crates.io/crates/barter-instrument
-[`Barter-Integration`]: https://crates.io/crates/barter-integration
+[`Jackbot`]: https://crates.io/crates/barter
+[`Jackbot-Data`]: https://crates.io/crates/barter-data
+[`Jackbot-Instrument`]: https://crates.io/crates/barter-instrument
+[`Jackbot-Integration`]: https://crates.io/crates/barter-integration
 [barter-examples]: https://github.com/barter-rs/barter-rs/tree/develop/barter/examples
 [API Documentation]: https://docs.rs/barter-execution/latest/barter_execution
 [Chat]: https://discord.gg/wE7RqhnQMV
@@ -39,24 +39,24 @@ a feature rich simulated exchange to assist with backtesting and dry-trading. Co
 initialising it's associated `ExecutionClient` instance. 
 
 ## Examples
-* See [here][barter-examples] for example of Barter-Instrument in action.
+* See [here][barter-examples] for example of Jackbot-Instrument in action.
 * See other sub-crates for further examples of each library.
 
 ## Getting Help
 Firstly, see if the answer to your question can be found in the [API Documentation]. If the answer is not there, I'd be happy to help via [Chat]
 and try answer your question via Discord.
 
-## Support Barter Development
-Help us advance Barter's capabilities by becoming a sponsor (or supporting me with a tip!).
+## Support Jackbot Development
+Help us advance Jackbot's capabilities by becoming a sponsor (or supporting me with a tip!).
 
-Your contribution will allow me to dedicate more time to Barter, accelerating feature development and improvements.
+Your contribution will allow me to dedicate more time to Jackbot, accelerating feature development and improvements.
 
 **Please email *justastream.code@gmail.com* for all inquiries**
 
 Please see [here](../README.md#support-barter-development) for more information.
 
 ## Contributing
-Thanks in advance for helping to develop the Barter ecosystem! Please do get hesitate to get touch via the Discord [Chat] to discuss development,
+Thanks in advance for helping to develop the Jackbot ecosystem! Please do get hesitate to get touch via the Discord [Chat] to discuss development,
 new features, and the future roadmap.
 
 ### Licence
@@ -66,7 +66,7 @@ This project is licensed under the [MIT license].
 
 ### Contribution License Agreement
 
-Any contribution you intentionally submit for inclusion in Barter workspace crates shall be:
+Any contribution you intentionally submit for inclusion in Jackbot workspace crates shall be:
 1. Licensed under MIT
 2. Subject to all disclaimers and limitations of liability stated below
 3. Provided without any additional terms or conditions

--- a/barter-execution/src/lib.rs
+++ b/barter-execution/src/lib.rs
@@ -12,14 +12,14 @@
 )]
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
-//! # Barter-Execution
+//! # Jackbot-Execution
 //! Stream private account data from financial venues, and execute (live or mock) orders. Also provides
 //! a feature rich MockExchange and MockExecutionClient to assist with backtesting and paper-trading.
 //!
 //! **It is:**
 //! * **Easy**: ExecutionClient trait provides a unified and simple language for interacting with exchanges.
 //! * **Normalised**: Allow your strategy to communicate with every real or MockExchange using the same interface.
-//! * **Extensible**: Barter-Execution is highly extensible, making it easy to contribute by adding new exchange integrations!
+//! * **Extensible**: Jackbot-Execution is highly extensible, making it easy to contribute by adding new exchange integrations!
 //!
 //! See `README.md` for more information and examples.
 

--- a/barter-execution/src/map.rs
+++ b/barter-execution/src/map.rs
@@ -9,7 +9,7 @@ use barter_instrument::{
 use barter_integration::collection::{FnvIndexMap, FnvIndexSet};
 use fnv::FnvHashMap;
 
-/// Indexed instrument map used to associate the internal Barter representation of instruments and
+/// Indexed instrument map used to associate the internal Jackbot representation of instruments and
 /// assets with the [`ExecutionClient`](super::client::ExecutionClient) representation.
 ///
 /// Similarly, when the execution manager received an [`AccountEvent`](super::AccountEvent)

--- a/barter-instrument/Cargo.toml
+++ b/barter-instrument/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 documentation = "https://docs.rs/barter-instrument"
 repository = "https://github.com/barter-rs/barter-rs"
 readme = "README.md"
-description = "Core Barter Exchange, Instrument and Asset data structures and associated utilities."
+description = "Core Jackbot Exchange, Instrument and Asset data structures and associated utilities."
 keywords = ["trading", "backtesting", "crypto", "stocks", "investment"]
 categories = ["accessibility", "simulation"]
 

--- a/barter-instrument/README.md
+++ b/barter-instrument/README.md
@@ -1,8 +1,8 @@
-# Barter-Instrument
-Barter-Instrument contains core Exchange, Instrument and Asset data structures and associated utilities.
+# Jackbot-Instrument
+Jackbot-Instrument contains core Exchange, Instrument and Asset data structures and associated utilities.
 
-**See: [`Barter`], [`Barter-Data`], [`Barter-Execution`] & [`Barter-Integration`] for
-comprehensive documentation of other Barter libraries.**
+**See: [`Jackbot`], [`Jackbot-Data`], [`Jackbot-Execution`] & [`Jackbot-Integration`] for
+comprehensive documentation of other Jackbot libraries.**
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -17,37 +17,37 @@ comprehensive documentation of other Barter libraries.**
 [discord-badge]: https://img.shields.io/discord/910237311332151317.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/wE7RqhnQMV
 
-[`Barter`]: https://crates.io/crates/barter
-[`Barter-Data`]: https://crates.io/crates/barter-data
-[`Barter-Execution`]: https://crates.io/crates/barter-execution
-[`Barter-Integration`]: https://crates.io/crates/barter-integration
+[`Jackbot`]: https://crates.io/crates/barter
+[`Jackbot-Data`]: https://crates.io/crates/barter-data
+[`Jackbot-Execution`]: https://crates.io/crates/barter-execution
+[`Jackbot-Integration`]: https://crates.io/crates/barter-integration
 [API Documentation]: https://docs.rs/barter/latest/barter/
 [Chat]: https://discord.gg/wE7RqhnQMV
 
 ## Overview
-Barter-Instrument contains core Exchange, Instrument and Asset data structures and associated utilities.
+Jackbot-Instrument contains core Exchange, Instrument and Asset data structures and associated utilities.
 
 [barter-examples]: https://github.com/barter-rs/barter-rs/tree/develop/barter/examples
 
 ## Examples
-* See [here][barter-examples] for example of Barter-Instrument in action.
+* See [here][barter-examples] for example of Jackbot-Instrument in action.
 * See other sub-crates for further examples of each library.
 
 ## Getting Help
 Firstly, see if the answer to your question can be found in the [API Documentation]. If the answer is not there, I'd be happy to help via [Chat]
 and try answer your question via Discord.
 
-## Support Barter Development
-Help us advance Barter's capabilities by becoming a sponsor (or supporting me with a tip!).
+## Support Jackbot Development
+Help us advance Jackbot's capabilities by becoming a sponsor (or supporting me with a tip!).
 
-Your contribution will allow me to dedicate more time to Barter, accelerating feature development and improvements.
+Your contribution will allow me to dedicate more time to Jackbot, accelerating feature development and improvements.
 
 **Please email *justastream.code@gmail.com* for all inquiries**
 
 Please see [here](../README.md#support-barter-development) for more information.
 
 ## Contributing
-Thanks in advance for helping to develop the Barter ecosystem! Please do get hesitate to get touch via the Discord [Chat] to discuss development,
+Thanks in advance for helping to develop the Jackbot ecosystem! Please do get hesitate to get touch via the Discord [Chat] to discuss development,
 new features, and the future roadmap.
 
 ### Licence
@@ -57,7 +57,7 @@ This project is licensed under the [MIT license].
 
 ### Contribution License Agreement
 
-Any contribution you intentionally submit for inclusion in Barter workspace crates shall be:
+Any contribution you intentionally submit for inclusion in Jackbot workspace crates shall be:
 1. Licensed under MIT
 2. Subject to all disclaimers and limitations of liability stated below
 3. Provided without any additional terms or conditions

--- a/barter-instrument/src/asset/name.rs
+++ b/barter-instrument/src/asset/name.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use smol_str::{SmolStr, StrExt};
 use std::borrow::Borrow;
 
-/// Barter lowercase `SmolStr` representation for an [`Asset`](super::Asset) - not unique across
+/// Jackbot lowercase `SmolStr` representation for an [`Asset`](super::Asset) - not unique across
 /// exchanges.
 ///
 /// This may or may not be different from an execution's representation.

--- a/barter-instrument/src/instrument/market_data/mod.rs
+++ b/barter-instrument/src/instrument/market_data/mod.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 
 pub mod kind;
 
-/// Barter representation of an `MarketDataInstrument`. Used to uniquely identify a `base_quote`
+/// Jackbot representation of an `MarketDataInstrument`. Used to uniquely identify a `base_quote`
 /// pair, and it's associated instrument type.
 ///
 /// eg/ MarketDataInstrument { base: "btc", quote: "usdt", kind: Spot }

--- a/barter-instrument/src/instrument/name.rs
+++ b/barter-instrument/src/instrument/name.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use smol_str::{SmolStr, StrExt, format_smolstr};
 use std::borrow::Borrow;
 
-/// Barter lowercase `SmolStr` representation for an [`Instrument`](super::Instrument) - unique
+/// Jackbot lowercase `SmolStr` representation for an [`Instrument`](super::Instrument) - unique
 /// across all exchanges.
 ///
 /// Note: Binance btc_usdt spot is not considered the same instrument as Bitfinex btc_usdt spot.

--- a/barter-instrument/src/lib.rs
+++ b/barter-instrument/src/lib.rs
@@ -12,11 +12,11 @@
 )]
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
-//! # Barter-Instrument
-//! Barter-Instrument contains core Exchange, Instrument and Asset data structures and associated utilities.
+//! # Jackbot-Instrument
+//! Jackbot-Instrument contains core Exchange, Instrument and Asset data structures and associated utilities.
 //!
 //! ## Examples
-//! For a comprehensive collection of examples, see the Barter core Engine /examples directory.
+//! For a comprehensive collection of examples, see the Jackbot core Engine /examples directory.
 
 use derive_more::Constructor;
 use serde::{Deserialize, Serialize};

--- a/barter-integration/Cargo.toml
+++ b/barter-integration/Cargo.toml
@@ -16,7 +16,7 @@ tokio-test = { workspace = true }
 sha2 = { workspace = true }
 
 [dependencies]
-# Barter Ecosystem
+# Jackbot Ecosystem
 barter-instrument = { workspace = true }
 
 # Logging

--- a/barter-integration/LICENSE
+++ b/barter-integration/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Barter-Integration Contributors
+Copyright (c) 2022 Jackbot-Integration Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/barter-integration/README.md
+++ b/barter-integration/README.md
@@ -1,8 +1,8 @@
-# Barter-Integration
+# Jackbot-Integration
 
 High-performance, low-level framework for composing flexible web integrations. 
 
-Utilised by other [`Barter`] trading ecosystem crates to build robust financial exchange integrations,
+Utilised by other [`Jackbot`] trading ecosystem crates to build robust financial exchange integrations,
 primarily for public data collection & trade execution. It is:
 * **Low-Level**: Translates raw data streams communicated over the web into any desired data model using arbitrary data transformations.
 * **Flexible**: Compatible with any protocol (WebSocket, FIX, Http, etc.), any input/output model, and any user defined transformations.
@@ -14,7 +14,7 @@ Core abstractions include:
 Both core abstractions provide the robust glue you need to conveniently translate between server & client data models.
 
 
-**See: [`Barter`], [`Barter-Data`] & [`Barter-Execution`]**
+**See: [`Jackbot`], [`Jackbot-Data`] & [`Jackbot-Execution`]**
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -35,15 +35,15 @@ Both core abstractions provide the robust glue you need to conveniently translat
 
 [API Documentation] | [Chat]
 
-[`Barter`]: https://crates.io/crates/barter
-[`Barter-Data`]: https://crates.io/crates/barter-data
-[`Barter-Execution`]: https://crates.io/crates/barter-execution
+[`Jackbot`]: https://crates.io/crates/barter
+[`Jackbot-Data`]: https://crates.io/crates/barter-data
+[`Jackbot-Execution`]: https://crates.io/crates/barter-execution
 [API Documentation]: https://docs.rs/barter-data/latest/barter_integration
 [Chat]: https://discord.gg/wE7RqhnQMV
 
 ## Overview
 
-Barter-Integration is a high-performance, low-level, configurable framework for composing flexible web 
+Jackbot-Integration is a high-performance, low-level, configurable framework for composing flexible web 
 integrations. 
 
 ### RestClient
@@ -201,7 +201,7 @@ struct FtxBalance {
     total: f64,
 }
 
-/// See Barter-Execution for a comprehensive real-life example, as well as code you can use out of the
+/// See Jackbot-Execution for a comprehensive real-life example, as well as code you can use out of the
 /// box to execute trades on many exchanges.
 #[tokio::main]
 async fn main() {
@@ -285,7 +285,7 @@ impl Transformer<VolumeSum> for StatefulTransformer {
     }
 }
 
-/// See Barter-Data for a comprehensive real-life example, as well as code you can use out of the
+/// See Jackbot-Data for a comprehensive real-life example, as well as code you can use out of the
 /// box to collect real-time public market data from many exchanges.
 #[tokio::main]
 async fn main() {
@@ -335,23 +335,23 @@ where
     data.parse::<T>().map_err(de::Error::custom)
 }
 ```
-**For a larger, "real world" example, see the [`Barter-Data`] repository.**
+**For a larger, "real world" example, see the [`Jackbot-Data`] repository.**
 
 ## Getting Help
 Firstly, see if the answer to your question can be found in the [API Documentation]. If the answer is not there, I'd be
 happy to help to [Chat] and try answer your question via Discord.
 
 ## Contributing
-Thanks for your help in improving the Barter ecosystem! Please do get in touch on the discord to discuss
+Thanks for your help in improving the Jackbot ecosystem! Please do get in touch on the discord to discuss
 development, new features, and the future roadmap.
 
 ## Related Projects
-In addition to the Barter-Integration crate, the Barter project also maintains:
-* [`Barter`]: High-performance, extensible & modular trading components with batteries-included. Contains a
+In addition to the Jackbot-Integration crate, the Jackbot project also maintains:
+* [`Jackbot`]: High-performance, extensible & modular trading components with batteries-included. Contains a
   pre-built trading Engine that can serve as a live-trading or backtesting system.
-* [`Barter-Data`]: A high-performance WebSocket integration library for streaming public data from leading 
+* [`Jackbot-Data`]: A high-performance WebSocket integration library for streaming public data from leading 
   cryptocurrency exchanges.
-* [`Barter-Execution`]: Financial exchange integrations for trade execution - yet to be released!
+* [`Jackbot-Execution`]: Financial exchange integrations for trade execution - yet to be released!
 
 ## Roadmap
 * Add new default StreamParser implementations to enable integration with other popular systems such as Kafka. 
@@ -363,5 +363,5 @@ This project is licensed under the [MIT license].
 
 ### Contribution
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Barter-Integration by you, shall be licensed as MIT, without any additional
+for inclusion in Jackbot-Integration by you, shall be licensed as MIT, without any additional
 terms or conditions.

--- a/barter-integration/examples/signed_get_request.rs
+++ b/barter-integration/examples/signed_get_request.rs
@@ -132,7 +132,7 @@ struct FtxBalance {
     total: f64,
 }
 
-/// See Barter-Execution for a comprehensive real-life example, as well as code you can use out of the
+/// See Jackbot-Execution for a comprehensive real-life example, as well as code you can use out of the
 /// box to execute trades on many exchanges.
 #[tokio::main]
 async fn main() {

--- a/barter-integration/examples/simple_websocket_integration.rs
+++ b/barter-integration/examples/simple_websocket_integration.rs
@@ -58,7 +58,7 @@ impl Transformer for StatefulTransformer {
     }
 }
 
-/// See Barter-Data for a comprehensive real-life example, as well as code you can use out of the
+/// See Jackbot-Data for a comprehensive real-life example, as well as code you can use out of the
 /// box to collect real-time public market data from many exchanges.
 #[tokio::main]
 async fn main() {

--- a/barter-integration/src/lib.rs
+++ b/barter-integration/src/lib.rs
@@ -12,10 +12,10 @@
 )]
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
-//! # Barter-Integration
+//! # Jackbot-Integration
 //! High-performance, low-level framework for composing flexible web integrations.
 //!
-//! Utilised by other Barter trading ecosystem crates to build robust financial execution integrations,
+//! Utilised by other Jackbot trading ecosystem crates to build robust financial execution integrations,
 //! primarily for public data collection & trade execution. It is:
 //! * **Low-Level**: Translates raw data streams communicated over the web into any desired data model using arbitrary data transformations.
 //! * **Flexible**: Compatible with any protocol (WebSocket, FIX, Http, etc.), any input/output model, and any user defined transformations.
@@ -29,7 +29,7 @@
 use crate::error::SocketError;
 use serde::{Deserialize, Serialize};
 
-/// All [`Error`](std::error::Error)s generated in Barter-Integration.
+/// All [`Error`](std::error::Error)s generated in Jackbot-Integration.
 pub mod error;
 
 /// Contains `StreamParser` implementations for transforming communication protocol specific

--- a/barter-integration/src/subscription.rs
+++ b/barter-integration/src/subscription.rs
@@ -5,8 +5,8 @@ use std::fmt::{Display, Formatter};
 /// New type representing a unique `String` identifier for a stream that has been subscribed to.
 /// This is used to identify data structures received over the socket.
 ///
-/// For example, `Barter-Data` uses this identifier to associate received data structures from the
-/// execution with the original `Barter-Data` `Subscription` that was actioned over the socket.
+/// For example, `Jackbot-Data` uses this identifier to associate received data structures from the
+/// execution with the original `Jackbot-Data` `Subscription` that was actioned over the socket.
 ///
 /// Note: Each execution will require the use of different `String` identifiers depending on the
 /// data structures they send.

--- a/barter-macro/Cargo.toml
+++ b/barter-macro/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 license = "MIT"
 documentation = "https://docs.rs/barter-macro/"
 repository = "https://github.com/barter-rs/barter-rs"
-description = "Barter ecosystem macros"
+description = "Jackbot ecosystem macros"
 keywords = ["trading", "backtesting", "crypto", "stocks", "investment"]
 categories = ["accessibility", "simulation"]
 

--- a/barter-macro/LICENSE
+++ b/barter-macro/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Barter
+Copyright (c) 2023 Jackbot
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/barter/Cargo.toml
+++ b/barter/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { workspace = true, features = ["fs"]}
 criterion = { workspace = true }
 
 [dependencies]
-# Barter Ecosystem
+# Jackbot Ecosystem
 barter-integration = { workspace = true }
 barter-instrument = { workspace = true }
 barter-data = { workspace = true }

--- a/barter/LICENSE
+++ b/barter/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Barter Contributors
+Copyright (c) 2021 Jackbot Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/barter/README.md
+++ b/barter/README.md
@@ -1,12 +1,12 @@
-# Barter
-Barter core is a Rust framework for building high-performance live-trading, paper-trading and back-testing systems.
+# Jackbot
+Jackbot core is a Rust framework for building high-performance live-trading, paper-trading and back-testing systems.
 * **Fast**: Written in native Rust. Minimal allocations. Data-oriented state management system with direct index lookups.
 * **Robust**: Strongly typed. Thread safe. Extensive test coverage.
 * **Customisable**: Plug and play Strategy and RiskManager components that facilitates most trading strategies (MarketMaking, StatArb, HFT, etc.).
 * **Scalable**: Multithreaded architecture with modular design. Leverages Tokio for I/O. Memory efficient data structures.
 
-**See: [`Barter-Data`], [`Barter-Instrument`], [`Barter-Execution`] & [`Barter-Integration`] for
-comprehensive documentation of other Barter libraries.**
+**See: [`Jackbot-Data`], [`Jackbot-Instrument`], [`Jackbot-Execution`] & [`Jackbot-Integration`] for
+comprehensive documentation of other Jackbot libraries.**
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -21,15 +21,15 @@ comprehensive documentation of other Barter libraries.**
 [discord-badge]: https://img.shields.io/discord/910237311332151317.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/wE7RqhnQMV
 
-[`Barter-Instrument`]: https://crates.io/crates/barter-instrument
-[`Barter-Data`]: https://crates.io/crates/barter-data
-[`Barter-Execution`]: https://crates.io/crates/barter-execution
-[`Barter-Integration`]: https://crates.io/crates/barter-integration
+[`Jackbot-Instrument`]: https://crates.io/crates/barter-instrument
+[`Jackbot-Data`]: https://crates.io/crates/barter-data
+[`Jackbot-Execution`]: https://crates.io/crates/barter-execution
+[`Jackbot-Integration`]: https://crates.io/crates/barter-integration
 [API Documentation]: https://docs.rs/barter/latest/barter/
 [Chat]: https://discord.gg/wE7RqhnQMV
 
 ## Overview
-Barter core is a Rust framework for building professional grade live-trading, paper-trading and back-testing systems. The
+Jackbot core is a Rust framework for building professional grade live-trading, paper-trading and back-testing systems. The
 central Engine facilitates executing on many exchanges simultaneously, and offers the flexibility to run most types of
 trading strategies. It allows turning algorithmic order generation on/off and can action Commands issued from external
 processes (eg/ CloseAllPositions, OpenOrders, CancelOrders, etc.)
@@ -138,17 +138,17 @@ fn load_config() -> Result<SystemConfig, Box<dyn std::error::Error>> {
 Firstly, see if the answer to your question can be found in the [API Documentation]. If the answer is not there, I'd be happy to help via [Chat]
 and try answer your question via Discord.
 
-## Support Barter Development
-Help us advance Barter's capabilities by becoming a sponsor (or supporting me with a tip!).
+## Support Jackbot Development
+Help us advance Jackbot's capabilities by becoming a sponsor (or supporting me with a tip!).
 
-Your contribution will allow me to dedicate more time to Barter, accelerating feature development and improvements.
+Your contribution will allow me to dedicate more time to Jackbot, accelerating feature development and improvements.
 
 **Please email *justastream.code@gmail.com* for all inquiries**
 
 Please see [here](../README.md#support-barter-development) for more information.
 
 ## Contributing
-Thanks in advance for helping to develop the Barter ecosystem! Please do get hesitate to get touch via the Discord[Chat] to discuss development,
+Thanks in advance for helping to develop the Jackbot ecosystem! Please do get hesitate to get touch via the Discord[Chat] to discuss development,
 new features, and the future roadmap.
 
 ### Licence
@@ -158,7 +158,7 @@ This project is licensed under the [MIT license].
 
 ### Contribution License Agreement
 
-Any contribution you intentionally submit for inclusion in Barter workspace crates shall be:
+Any contribution you intentionally submit for inclusion in Jackbot workspace crates shall be:
 1. Licensed under MIT
 2. Subject to all disclaimers and limitations of liability stated below
 3. Provided without any additional terms or conditions

--- a/barter/src/backtest/market_data.rs
+++ b/barter/src/backtest/market_data.rs
@@ -1,4 +1,4 @@
-use crate::error::BarterError;
+use crate::error::JackbotError;
 use barter_data::streams::consumer::MarketStreamEvent;
 use barter_instrument::instrument::InstrumentIndex;
 use chrono::{DateTime, Utc};
@@ -11,7 +11,7 @@ pub trait BacktestMarketData {
     type Kind;
 
     /// Return the `DateTime<Utc>` of the first event in the market data `Stream`.
-    fn time_first_event(&self) -> impl Future<Output = Result<DateTime<Utc>, BarterError>>;
+    fn time_first_event(&self) -> impl Future<Output = Result<DateTime<Utc>, JackbotError>>;
 
     /// Return a `Stream` of `MarketStreamEvent`s.
     fn stream(
@@ -19,7 +19,7 @@ pub trait BacktestMarketData {
     ) -> impl Future<
         Output = Result<
             impl Stream<Item = MarketStreamEvent<InstrumentIndex, Self::Kind>> + Send + 'static,
-            BarterError,
+            JackbotError,
         >,
     >;
 }
@@ -40,7 +40,7 @@ where
 {
     type Kind = Kind;
 
-    async fn time_first_event(&self) -> Result<DateTime<Utc>, BarterError> {
+    async fn time_first_event(&self) -> Result<DateTime<Utc>, JackbotError> {
         Ok(self.time_first_event)
     }
 
@@ -48,7 +48,7 @@ where
         &self,
     ) -> Result<
         impl Stream<Item = MarketStreamEvent<InstrumentIndex, Self::Kind>> + Send + 'static,
-        BarterError,
+        JackbotError,
     > {
         let events = Arc::clone(&self.events);
         let lazy_clone_iter = (0..events.len()).map(move |index| events[index].clone());

--- a/barter/src/backtest/mod.rs
+++ b/barter/src/backtest/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         execution_tx::MultiExchangeTxMap,
         state::{EngineState, instrument::data::InstrumentDataState},
     },
-    error::BarterError,
+    error::JackbotError,
     risk::RiskManager,
     statistic::time::TimeInterval,
     strategy::{
@@ -90,7 +90,7 @@ pub async fn run_backtests<
         BacktestArgsConstant<MarketData, SummaryInterval, EngineState<GlobalData, InstrumentData>>,
     >,
     args_dynamic_iter: impl IntoIterator<Item = BacktestArgsDynamic<Strategy, Risk>>,
-) -> Result<MultiBacktestSummary<SummaryInterval>, BarterError>
+) -> Result<MultiBacktestSummary<SummaryInterval>, JackbotError>
 where
     MarketData: BacktestMarketData<Kind = InstrumentData::MarketEventKind>,
     SummaryInterval: TimeInterval,
@@ -153,7 +153,7 @@ pub async fn backtest<MarketData, SummaryInterval, Strategy, Risk, GlobalData, I
         BacktestArgsConstant<MarketData, SummaryInterval, EngineState<GlobalData, InstrumentData>>,
     >,
     args_dynamic: BacktestArgsDynamic<Strategy, Risk>,
-) -> Result<BacktestSummary<SummaryInterval>, BarterError>
+) -> Result<BacktestSummary<SummaryInterval>, JackbotError>
 where
     MarketData: BacktestMarketData<Kind = InstrumentData::MarketEventKind>,
     SummaryInterval: TimeInterval,

--- a/barter/src/error.rs
+++ b/barter/src/error.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Error)]
-pub enum BarterError {
+pub enum JackbotError {
     #[error("IndexError: {0}")]
     IndexError(#[from] IndexError),
 
@@ -34,13 +34,13 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for RxDropped {
     }
 }
 
-impl<T> From<tokio::sync::mpsc::error::SendError<T>> for BarterError {
+impl<T> From<tokio::sync::mpsc::error::SendError<T>> for JackbotError {
     fn from(_: tokio::sync::mpsc::error::SendError<T>) -> Self {
         Self::ExecutionRxDropped(RxDropped)
     }
 }
 
-impl From<tokio::task::JoinError> for BarterError {
+impl From<tokio::task::JoinError> for JackbotError {
     fn from(value: tokio::task::JoinError) -> Self {
         Self::JoinError(format!("{value:?}"))
     }

--- a/barter/src/execution/builder.rs
+++ b/barter/src/execution/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     engine::{clock::EngineClock, execution_tx::MultiExchangeTxMap},
-    error::BarterError,
+    error::JackbotError,
     execution::{
         AccountStreamEvent, Execution, error::ExecutionError, manager::ExecutionManager,
         request::ExecutionRequest,
@@ -89,7 +89,7 @@ impl<'a> ExecutionBuilder<'a> {
         mut self,
         config: MockExecutionConfig,
         clock: Clock,
-    ) -> Result<Self, BarterError>
+    ) -> Result<Self, JackbotError>
     where
         Clock: EngineClock + Clone + Send + Sync + 'static,
     {
@@ -133,7 +133,7 @@ impl<'a> ExecutionBuilder<'a> {
         self,
         config: Client::Config,
         request_timeout: Duration,
-    ) -> Result<Self, BarterError>
+    ) -> Result<Self, JackbotError>
     where
         Client: ExecutionClient + Send + Sync + 'static,
         Client::AccountStream: Send,
@@ -147,7 +147,7 @@ impl<'a> ExecutionBuilder<'a> {
         exchange: ExchangeId,
         config: Client::Config,
         request_timeout: Duration,
-    ) -> Result<Self, BarterError>
+    ) -> Result<Self, JackbotError>
     where
         Client: ExecutionClient + Send + Sync + 'static,
         Client::AccountStream: Send,
@@ -162,7 +162,7 @@ impl<'a> ExecutionBuilder<'a> {
             .insert(exchange, (instrument_map.exchange.key, execution_tx))
             .is_some()
         {
-            return Err(BarterError::ExecutionBuilder(format!(
+            return Err(JackbotError::ExecutionBuilder(format!(
                 "ExecutionBuilder does not support duplicate mocked ExecutionManagers: {exchange}"
             )));
         }
@@ -252,7 +252,7 @@ impl ExecutionBuild {
     /// - Spawns [`MockExchange`] runners tokio tasks.
     /// - Initialises all [`ExecutionManager`]s and their AccountStreams.
     /// - Returns the `MultiExchangeTxMap` and multi-exchange AccountStream.
-    pub async fn init(self) -> Result<Execution, BarterError> {
+    pub async fn init(self) -> Result<Execution, JackbotError> {
         self.init_internal(tokio::runtime::Handle::current()).await
     }
 
@@ -268,14 +268,14 @@ impl ExecutionBuild {
     pub async fn init_with_runtime(
         self,
         runtime: tokio::runtime::Handle,
-    ) -> Result<Execution, BarterError> {
+    ) -> Result<Execution, JackbotError> {
         self.init_internal(runtime).await
     }
 
     async fn init_internal(
         self,
         runtime: tokio::runtime::Handle,
-    ) -> Result<Execution, BarterError> {
+    ) -> Result<Execution, JackbotError> {
         let handles = self.futures.init_with_runtime(runtime).await?;
 
         Ok(Execution {
@@ -299,7 +299,7 @@ impl ExecutionBuildFutures {
     /// - Spawns [`MockExchange`] runner tokio tasks.
     /// - Initialises all [`ExecutionManager`]s and their AccountStreams.
     /// - Spawns tokio tasks to forward AccountStreams to multi-exchange AccountStream
-    pub async fn init(self) -> Result<ExecutionHandles, BarterError> {
+    pub async fn init(self) -> Result<ExecutionHandles, JackbotError> {
         self.init_internal(tokio::runtime::Handle::current()).await
     }
 
@@ -315,14 +315,14 @@ impl ExecutionBuildFutures {
     pub async fn init_with_runtime(
         self,
         runtime: tokio::runtime::Handle,
-    ) -> Result<ExecutionHandles, BarterError> {
+    ) -> Result<ExecutionHandles, JackbotError> {
         self.init_internal(runtime).await
     }
 
     async fn init_internal(
         self,
         runtime: tokio::runtime::Handle,
-    ) -> Result<ExecutionHandles, BarterError> {
+    ) -> Result<ExecutionHandles, JackbotError> {
         let mock_exchanges = self
             .mock_exchange_run_futures
             .into_iter()

--- a/barter/src/lib.rs
+++ b/barter/src/lib.rs
@@ -12,15 +12,15 @@
 )]
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
-//! # Barter
-//! Barter core is a Rust framework for building high-performance live-trading, paper-trading and back-testing systems.
+//! # Jackbot
+//! Jackbot core is a Rust framework for building high-performance live-trading, paper-trading and back-testing systems.
 //! * **Fast**: Written in native Rust. Minimal allocations. Data-oriented state management system with direct index lookups.
 //! * **Robust**: Strongly typed. Thread safe. Extensive test coverage.
 //! * **Customisable**: Plug and play Strategy and RiskManager components that facilitates most trading strategies (MarketMaking, StatArb, HFT, etc.).
 //! * **Scalable**: Multithreaded architecture with modular design. Leverages Tokio for I/O. Memory efficient data structures.
 //!
 //! ## Overview
-//! Barter core is a Rust framework for building professional grade live-trading, paper-trading and back-testing systems. The
+//! Jackbot core is a Rust framework for building professional grade live-trading, paper-trading and back-testing systems. The
 //! central Engine facilitates executing on many exchanges simultaneously, and offers the flexibility to run most types of
 //! trading strategies.  It allows turning algorithmic order generation on/off and can action Commands issued from external
 //! processes (eg/ CloseAllPositions, OpenOrders, CancelOrders, etc.)
@@ -58,14 +58,14 @@ use shutdown::Shutdown;
 /// eg/ `Engine`, `run`, `process_with_audit`, etc.
 pub mod engine;
 
-/// Defines all possible errors in Barter core.
+/// Defines all possible errors in Jackbot core.
 pub mod error;
 
 /// Components for initialising multi-exchange execution, routing `ExecutionRequest`s and other
 /// execution logic.
 pub mod execution;
 
-/// Provides default Barter core Tracing logging initialisers.
+/// Provides default Jackbot core Tracing logging initialisers.
 pub mod logging;
 
 /// RiskManager interface for reviewing and optionally filtering algorithmic cancel and open
@@ -179,7 +179,7 @@ impl Sequence {
     }
 }
 
-/// Barter core test utilities.
+/// Jackbot core test utilities.
 pub mod test_utils {
     use crate::{
         Timed, engine::state::asset::AssetState, statistic::summary::asset::TearSheetAssetGenerator,

--- a/barter/src/logging.rs
+++ b/barter/src/logging.rs
@@ -1,7 +1,7 @@
 use crate::engine::audit::state_replica::AUDIT_REPLICA_STATE_UPDATE_SPAN_NAME;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-/// Initialise default non-JSON `Barter` logging.
+/// Initialise default non-JSON `Jackbot` logging.
 ///
 /// Note that this filters out duplicate logs produced by the `AuditManager` updating its replica
 /// `EngineState`.
@@ -17,7 +17,7 @@ pub fn init_logging() {
         .init()
 }
 
-/// Initialise default JSON `Barter` logging.
+/// Initialise default JSON `Jackbot` logging.
 ///
 /// Note that this filters out duplicate logs produced by the `AuditManager` updating its replica
 /// `EngineState`.

--- a/barter/src/strategy/algo.rs
+++ b/barter/src/strategy/algo.rs
@@ -10,7 +10,7 @@ use barter_instrument::{exchange::ExchangeIndex, instrument::InstrumentIndex};
 pub trait AlgoStrategy<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> {
     /// State used by the `AlgoStrategy` to determine what open and cancel requests to generate.
     ///
-    /// For Barter ecosystem strategies, this is the full `EngineState` of the trading system.
+    /// For Jackbot ecosystem strategies, this is the full `EngineState` of the trading system.
     ///
     /// eg/ `EngineState<DefaultGlobalData, DefaultInstrumentMarketData>`
     type State;

--- a/barter/src/strategy/close_positions.rs
+++ b/barter/src/strategy/close_positions.rs
@@ -36,7 +36,7 @@ pub trait ClosePositionsStrategy<
     /// State used by the `ClosePositionsStrategy` to determine what open and cancel requests
     /// to generate.
     ///
-    /// For Barter ecosystem strategies, this is the full `EngineState` of the trading system.
+    /// For Jackbot ecosystem strategies, this is the full `EngineState` of the trading system.
     ///
     /// eg/ `EngineState<DefaultGlobalData, DefaultInstrumentMarketData>`
     type State;

--- a/barter/src/system/builder.rs
+++ b/barter/src/system/builder.rs
@@ -7,7 +7,7 @@ use crate::{
         run::{async_run, async_run_with_audit, sync_run, sync_run_with_audit},
         state::{EngineState, builder::EngineStateBuilder, trading::TradingState},
     },
-    error::BarterError,
+    error::JackbotError,
     execution::{
         AccountStreamEvent,
         builder::{ExecutionBuildFutures, ExecutionBuilder},
@@ -60,9 +60,9 @@ pub enum AuditMode {
     Disabled,
 }
 
-/// Arguments required for building a full Barter trading system.
+/// Arguments required for building a full Jackbot trading system.
 ///
-/// Contains all the required components to build and initialise a full Barter trading system,
+/// Contains all the required components to build and initialise a full Jackbot trading system,
 /// including the `Engine` and all supporting infrastructure.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Constructor)]
 pub struct SystemArgs<'a, Clock, Strategy, Risk, MarketStream, GlobalData, FnInstrumentData> {
@@ -94,7 +94,7 @@ pub struct SystemArgs<'a, Clock, Strategy, Risk, MarketStream, GlobalData, FnIns
     pub instrument_data_init: FnInstrumentData,
 }
 
-/// Builder for constructing a full Barter trading system.
+/// Builder for constructing a full Jackbot trading system.
 #[derive(Debug)]
 pub struct SystemBuilder<'a, Clock, Strategy, Risk, MarketStream, GlobalData, FnInstrumentData> {
     args: SystemArgs<'a, Clock, Strategy, Risk, MarketStream, GlobalData, FnInstrumentData>,
@@ -191,7 +191,7 @@ impl<'a, Clock, Strategy, Risk, MarketStream, GlobalData, FnInstrumentData>
             Event,
             MarketStream,
         >,
-        BarterError,
+        JackbotError,
     >
     where
         Clock: EngineClock + Clone + Send + Sync + 'static,
@@ -319,7 +319,7 @@ where
     /// Initialise the system using the current tokio runtime.
     ///
     /// Spawns all necessary tasks and returns the running `System` instance.
-    pub async fn init(self) -> Result<System<Engine, Event>, BarterError> {
+    pub async fn init(self) -> Result<System<Engine, Event>, JackbotError> {
         self.init_internal(tokio::runtime::Handle::current()).await
     }
 
@@ -329,14 +329,14 @@ where
     pub async fn init_with_runtime(
         self,
         runtime: tokio::runtime::Handle,
-    ) -> Result<System<Engine, Event>, BarterError> {
+    ) -> Result<System<Engine, Event>, JackbotError> {
         self.init_internal(runtime).await
     }
 
     async fn init_internal(
         self,
         runtime: tokio::runtime::Handle,
-    ) -> Result<System<Engine, Event>, BarterError> {
+    ) -> Result<System<Engine, Event>, JackbotError> {
         let Self {
             mut engine,
             engine_feed_mode,

--- a/barter/src/system/mod.rs
+++ b/barter/src/system/mod.rs
@@ -23,13 +23,13 @@ use barter_integration::{
 use std::fmt::Debug;
 use tokio::task::{JoinError, JoinHandle};
 
-/// Provides a `SystemBuilder` for constructing a Barter trading system, and associated types.
+/// Provides a `SystemBuilder` for constructing a Jackbot trading system, and associated types.
 pub mod builder;
 
-/// Provides a convenient `SystemConfig` used for defining a Barter trading system.
+/// Provides a convenient `SystemConfig` used for defining a Jackbot trading system.
 pub mod config;
 
-/// Initialised and running Barter trading system.
+/// Initialised and running Jackbot trading system.
 ///
 /// Contains handles for the `Engine` and all auxillary system tasks.
 ///


### PR DESCRIPTION
## Summary
- rename references to Barter across the workspace to Jackbot

## Testing
- `cargo test --workspace` *(fails: failed to get `chrono` due to network access)*