### PR TITLE
Add multi-exchange L2 streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Jackbot Sensor
-Based on Barter is an algorithmic trading ecosystem of Rust libraries for building high-performance live-trading, paper-trading 
+Jackbot is an algorithmic trading ecosystem of Rust libraries for building high-performance live-trading, paper-trading
 and back-testing systems.
 * **Fast**: Written in native Rust. Minimal allocations. Data-oriented state management system with direct index lookups.
 * **Robust**: Strongly typed. Thread safe. Extensive test coverage.
 * **Customisable**: Plug and play Strategy and RiskManager components that facilitates most trading strategies (MarketMaking, StatArb, HFT, etc.).
 * **Scalable**: Multithreaded architecture with modular design. Leverages Tokio for I/O. Memory efficient data structures.  
 
-I expands Barter to support the exchanges of the Jackbot Terminal project:
-* Binance (Great reference implementation on Barter)
+This project expands Jackbot Terminal to support the following exchanges:
+* Binance
 * Bitget
 * Bybit 
 * Coinbase
@@ -18,26 +18,35 @@ I expands Barter to support the exchanges of the Jackbot Terminal project:
 ## Overview
 Jackbot Sensor is an algorithmic trading ecosystem of Rust libraries for building high-performance live-trading, paper-trading 
 and back-testing systems. It is made up of several easy-to-use, extensible crates:
-* **Barter**: Algorithmic trading Engine with feature rich state management system.
-* **Barter-Instrument**: Exchange, Instrument and Asset data structures and utilities. 
-* **Barter-Data**: Stream public market data from financial venues. Easily extensible via the MarketStream interface.
-* **Barter-Execution**: Stream private account data and execute orders. Easily extensible via the ExecutionClient interface. 
-* **Barter-Integration**: Low-level frameworks for flexible REST/WebSocket integrations.
+* **Jackbot**: Algorithmic trading Engine with feature rich state management system.
+* **Jackbot-Instrument**: Exchange, Instrument and Asset data structures and utilities.
+* **Jackbot-Data**: Stream public market data from financial venues. Easily extensible via the MarketStream interface.
+* **Jackbot-Execution**: Stream private account data and execute orders. Easily extensible via the ExecutionClient interface.
+* **Jackbot-Integration**: Low-level frameworks for flexible REST/WebSocket integrations.
 
 ## Notable Features
-- Stream public market data from financial venues via the [`Barter-Data`] library. 
-- Stream private account data, execute orders (live or mock)** via the [`Barter-Execution`] library.
+- Stream public market data from financial venues via the [`Jackbot-Data`] library.
+- Stream private account data, execute orders (live or mock)** via the [`Jackbot-Execution`] library.
 - Plug and play Strategy and RiskManager components that facilitate most trading strategies. 
 - Flexible Engine that facilitates trading strategies that execute on many exchanges simultaneously.
 - Use mock MarketStream or Execution components to enable back-testing on a near-identical trading system as live-trading.  
 - Centralised cache friendly state management system with O(1) constant lookups using indexed data structures.
 - Robust Order management system
+- Level 2 order book streaming across all supported exchanges.
 - Trading summaries with comprehensive performance metrics (PnL, Sharpe, Sortino, Drawdown, etc.).
 - Turn on/off algorithmic trading from an external process (eg/ UI, Telegram, etc.) whilst still processing market/account data. 
 - Issue Engine Commands from an external process (eg/ UI, Telegram, etc.) to initiate actions (CloseAllPositions, OpenOrders, CancelOrders, etc.).
 - EngineState replica manager that processes the Engine AuditStream to facilitate non-hot path monitoring components (eg/ UI, Telegram, etc.).
 - S3 data harvesting using parquet + iceberg for preserving data for later utilization to build even better algos.
 - Jackpot orderbook representation. Composed of a special kind of order sent from (UI, Telegram, etc.) that is not placeable in the current exchange orderbook because it is too out of money.
+
+### Examples
+The `barter-data` crate offers runnable examples demonstrating Jackbot data streams.
+To stream Level 2 order books from multiple exchanges run:
+
+```bash
+cargo run --package barter-data --example order_books_l2_streams_multi_exchange
+```
 
 ## Getting Help
 Reach out via mail@jackbot.app

--- a/barter-data/examples/order_books_l2_streams_multi_exchange.rs
+++ b/barter-data/examples/order_books_l2_streams_multi_exchange.rs
@@ -1,0 +1,57 @@
+use barter_data::{
+    exchange::binance::{futures::BinanceFuturesUsd, spot::BinanceSpot},
+    streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscription::book::OrderBooksL2,
+};
+use barter_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
+use futures::StreamExt;
+use tracing::{info, warn};
+
+#[rustfmt::skip]
+#[tokio::main]
+async fn main() {
+    // Initialise INFO Tracing log subscriber
+    init_logging();
+
+    // Initialise OrderBooksL2 Streams for multiple exchanges
+    // '--> each call to StreamBuilder::subscribe() initialises a separate WebSocket connection
+    let streams = Streams::<OrderBooksL2>::builder()
+        .subscribe([
+            (BinanceSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL2),
+            (BinanceSpot::default(), "eth", "usd", MarketDataInstrumentKind::Spot, OrderBooksL2),
+        ])
+        .subscribe([
+            (BinanceFuturesUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, OrderBooksL2),
+            (BinanceFuturesUsd::default(), "eth", "usd", MarketDataInstrumentKind::Perpetual, OrderBooksL2),
+        ])
+        .init()
+        .await
+        .unwrap();
+
+    // Select and merge every exchange Stream using futures_util::stream::select_all
+    // Note: use `Streams.select(ExchangeId)` to interact with individual exchange streams!
+    let mut joined_stream = streams
+        .select_all()
+        .with_error_handler(|error| warn!(?error, "MarketStream generated error"));
+
+    while let Some(event) = joined_stream.next().await {
+        info!("{event:?}");
+    }
+}
+
+// Initialise an INFO `Subscriber` for `Tracing` Json logs and install it as the global default.
+fn init_logging() {
+    tracing_subscriber::fmt()
+        // Filter messages based on the INFO
+        .with_env_filter(
+            tracing_subscriber::filter::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        // Disable colours on release builds
+        .with_ansi(cfg!(debug_assertions))
+        // Enable Json formatting
+        .json()
+        // Install this Tracing subscriber as global default
+        .init()
+}


### PR DESCRIPTION
## Summary
- showcase multi-exchange L2 streaming via new example
- rename project references from Barter to Jackbot in README
- document Level 2 order book support and usage example

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo check -p barter-data --examples` *(fails: unable to access crates.io)*