### PR TITLE
Implement jittered reconnection with tests

### DIFF
--- a/jackbot-data/src/streams/consumer.rs
+++ b/jackbot-data/src/streams/consumer.rs
@@ -24,6 +24,7 @@ pub const STREAM_RECONNECTION_POLICY: ReconnectionBackoffPolicy = ReconnectionBa
     backoff_ms_initial: 125,
     backoff_multiplier: 2,
     backoff_ms_max: 60000,
+    jitter_ms: 250,
 };
 
 /// Convenient type alias for a [`MarketEvent`] [`Result`] consumed via a


### PR DESCRIPTION
## Summary
- add jitter support to reconnection backoff
- log waiting durations before reconnecting
- expose backoff policy jitter configuration
- test backoff jitter calculations and reconnection flow

## Testing
- `cargo test --workspace --quiet` *(fails: failed to get `chrono` as a dependency)*