### PR TITLE
Implement Binance WebSocket support

### DIFF
--- a/jackbot-execution/src/client/binance/mod.rs
+++ b/jackbot-execution/src/client/binance/mod.rs
@@ -1,1 +1,238 @@
+use crate::{
+    balance::{AssetBalance, Balance},
+    client::ExecutionClient,
+    error::{UnindexedClientError, UnindexedOrderError},
+    order::{
+        Order,
+        OrderKey,
+        state::{Open, OrderState, ActiveOrderState},
+        id::{OrderId, ClientOrderId, StrategyId},
+        OrderKind,
+        TimeInForce,
+        request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
+    },
+    trade::Trade,
+    AccountEvent,
+    AccountEventKind,
+    UnindexedAccountSnapshot,
+};
+use jackbot_integration::protocol::websocket::{connect, WebSocket, WsMessage};
+use jackbot_integration::snapshot::Snapshot;
+use jackbot_instrument::{
+    asset::name::AssetNameExchange,
+    asset::QuoteAsset,
+    exchange::ExchangeId,
+    instrument::name::InstrumentNameExchange,
+    Side,
+};
+use chrono::{DateTime, Utc};
+use futures::{Stream, StreamExt};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use serde::Deserialize;
+use rust_decimal::Decimal;
+use std::{str::FromStr, time::Duration};
+use url::Url;
 
+#[derive(Clone, Debug)]
+pub struct BinanceWsConfig {
+    pub url: Url,
+    pub auth_payload: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct BinanceWsClient {
+    config: BinanceWsConfig,
+}
+
+impl ExecutionClient for BinanceWsClient {
+    const EXCHANGE: ExchangeId = ExchangeId::BinanceSpot;
+    type Config = BinanceWsConfig;
+    type AccountStream = UnboundedReceiverStream<UnindexedAccountEvent>;
+
+    fn new(config: Self::Config) -> Self {
+        Self { config }
+    }
+
+    async fn account_snapshot(
+        &self,
+        _assets: &[AssetNameExchange],
+        _instruments: &[InstrumentNameExchange],
+    ) -> Result<UnindexedAccountSnapshot, UnindexedClientError> {
+        Ok(UnindexedAccountSnapshot {
+            exchange: Self::EXCHANGE,
+            balances: vec![],
+            instruments: vec![],
+        })
+    }
+
+    async fn account_stream(
+        &self,
+        _assets: &[AssetNameExchange],
+        _instruments: &[InstrumentNameExchange],
+    ) -> Result<Self::AccountStream, UnindexedClientError> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let url = self.config.url.clone();
+        let auth = self.config.auth_payload.clone();
+        tokio::spawn(async move {
+            loop {
+                match connect(url.clone()).await {
+                    Ok(ws) => {
+                        if run_connection(ws, &tx, &auth).await.is_err() {
+                            tokio::time::sleep(Duration::from_millis(50)).await;
+                            continue;
+                        } else {
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                }
+            }
+        });
+        Ok(UnboundedReceiverStream::new(rx))
+    }
+
+    async fn cancel_order(
+        &self,
+        _request: OrderRequestCancel<ExchangeId, &InstrumentNameExchange>,
+    ) -> UnindexedOrderResponseCancel {
+        unimplemented!()
+    }
+
+    async fn open_order(
+        &self,
+        _request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
+    ) -> Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>> {
+        unimplemented!()
+    }
+
+    async fn fetch_balances(
+        &self,
+    ) -> Result<Vec<AssetBalance<AssetNameExchange>>, UnindexedClientError> {
+        unimplemented!()
+    }
+
+    async fn fetch_open_orders(
+        &self,
+    ) -> Result<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>, UnindexedClientError> {
+        unimplemented!()
+    }
+
+    async fn fetch_trades(
+        &self,
+        _time_since: DateTime<Utc>,
+    ) -> Result<Vec<Trade<QuoteAsset, InstrumentNameExchange>>, UnindexedClientError> {
+        unimplemented!()
+    }
+}
+
+async fn run_connection(
+    mut ws: WebSocket,
+    tx: &mpsc::UnboundedSender<UnindexedAccountEvent>,
+    auth: &str,
+) -> Result<(), ()> {
+    if ws.send(WsMessage::Text(auth.to_string())).await.is_err() {
+        return Err(());
+    }
+    while let Some(msg) = ws.next().await {
+        let msg = match msg {
+            Ok(m) => m,
+            Err(_) => return Err(()),
+        };
+        match msg {
+            WsMessage::Text(text) => {
+                if let Ok(event) = serde_json::from_str::<BinanceEvent>(&text) {
+                    if let Some(evt) = to_account_event(event) {
+                        let _ = tx.send(evt);
+                    }
+                }
+            }
+            WsMessage::Close(_) => return Err(()),
+            _ => {}
+        }
+    }
+    Err(())
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "e")]
+enum BinanceEvent {
+    #[serde(rename = "balance")]
+    Balance {
+        #[serde(rename = "E")]
+        time: u64,
+        asset: String,
+        free: String,
+        total: String,
+    },
+    #[serde(rename = "order")]
+    Order {
+        #[serde(rename = "E")]
+        time: u64,
+        #[serde(rename = "s")]
+        symbol: String,
+        #[serde(rename = "S")]
+        side: String,
+        #[serde(rename = "p")]
+        price: String,
+        #[serde(rename = "q")]
+        quantity: String,
+        #[serde(rename = "i")]
+        order_id: u64,
+        #[serde(rename = "X")]
+        status: String,
+    },
+}
+
+fn to_account_event(event: BinanceEvent) -> Option<UnindexedAccountEvent> {
+    match event {
+        BinanceEvent::Balance { time, asset, free, total } => {
+            let time = Utc.timestamp_millis_opt(time as i64).single()?;
+            let free = Decimal::from_str(&free).ok()?;
+            let total = Decimal::from_str(&total).ok()?;
+            let balance = AssetBalance {
+                asset: AssetNameExchange(asset),
+                balance: Balance { total, free },
+                time_exchange: time,
+            };
+            Some(AccountEvent::new(
+                ExchangeId::BinanceSpot,
+                AccountEventKind::BalanceSnapshot(Snapshot(balance)),
+            ))
+        }
+        BinanceEvent::Order { time, symbol, side, price, quantity, order_id, .. } => {
+            let time = Utc.timestamp_millis_opt(time as i64).single()?;
+            let side = match side.as_str() {
+                "BUY" => Side::Buy,
+                "SELL" => Side::Sell,
+                _ => return None,
+            };
+            let price = Decimal::from_str(&price).ok()?;
+            let quantity = Decimal::from_str(&quantity).ok()?;
+            let order = Order {
+                key: OrderKey {
+                    exchange: ExchangeId::BinanceSpot,
+                    instrument: InstrumentNameExchange(symbol),
+                    strategy: StrategyId::unknown(),
+                    cid: ClientOrderId::default(),
+                },
+                side,
+                price,
+                quantity,
+                kind: OrderKind::Market,
+                time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+                state: OrderState::active(Open {
+                    id: OrderId(order_id.to_string()),
+                    time_exchange: time,
+                    filled_quantity: quantity,
+                }),
+            };
+            Some(AccountEvent::new(
+                ExchangeId::BinanceSpot,
+                AccountEventKind::OrderSnapshot(Snapshot(order)),
+            ))
+        }
+    }
+}

--- a/jackbot-execution/src/client/mod.rs
+++ b/jackbot-execution/src/client/mod.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 use futures::Stream;
 use std::future::Future;
 
-mod binance;
+pub mod binance;
 pub mod mock;
 
 pub trait ExecutionClient

--- a/jackbot-execution/tests/binance_ws.rs
+++ b/jackbot-execution/tests/binance_ws.rs
@@ -1,0 +1,45 @@
+use jackbot_execution::{
+    client::{binance::{BinanceWsClient, BinanceWsConfig}, ExecutionClient},
+    AccountEventKind,
+};
+use tokio::{net::TcpListener};
+use tokio_tungstenite::{accept_async, tungstenite::Message};
+use futures::{SinkExt, StreamExt};
+use url::Url;
+
+async fn run_server(addr: &str, first: String, second: String) {
+    let listener = TcpListener::bind(addr).await.unwrap();
+    for payload in [first, second] {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        // recv auth
+        ws.next().await.unwrap().unwrap();
+        ws.send(Message::Text(payload)).await.unwrap();
+        ws.close(None).await.unwrap();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reconnect_and_normalise() {
+    let addr = "127.0.0.1:18080";
+    let first = r#"{\"e\":\"balance\",\"E\":1,\"asset\":\"BTC\",\"free\":\"0.5\",\"total\":\"1.0\"}"#.to_string();
+    let second = r#"{\"e\":\"order\",\"E\":2,\"s\":\"BTCUSDT\",\"S\":\"BUY\",\"p\":\"100\",\"q\":\"0.1\",\"i\":1,\"X\":\"NEW\"}"#.to_string();
+    tokio::spawn(run_server(addr, first.clone(), second.clone()));
+
+    let client = BinanceWsClient::new(BinanceWsConfig {
+        url: Url::parse(&format!("ws://{}", addr)).unwrap(),
+        auth_payload: "{}".to_string(),
+    });
+    let mut stream = client.account_stream(&[], &[]).await.unwrap();
+
+    let ev1 = stream.next().await.unwrap();
+    match ev1.kind {
+        AccountEventKind::BalanceSnapshot(_) => {}
+        _ => panic!("expected balance"),
+    }
+    let ev2 = stream.next().await.unwrap();
+    match ev2.kind {
+        AccountEventKind::OrderSnapshot(_) => {}
+        _ => panic!("expected order"),
+    }
+}


### PR DESCRIPTION
## Summary
- expose `binance` execution client module
- implement `BinanceWsClient` for authenticated WS balance and order events
- parse WS messages into normalised `AccountEvent`s
- test reconnection and event parsing via local WebSocket server

## Testing
- `cargo test --locked --offline` *(fails: failed to download crates)*