### PR TITLE
Add smart trade utilities

### DIFF
--- a/jackbot/src/lib.rs
+++ b/jackbot/src/lib.rs
@@ -81,6 +81,9 @@ pub mod statistic;
 /// `Engine` actions on disconnect / trading disabled.
 pub mod strategy;
 
+/// Smart trade utilities (trailing take profit, profit targets, trailing stops, multi-level stops).
+pub mod smart_trade;
+
 /// Utilities for initialising and interacting with a full trading system.
 pub mod system;
 

--- a/jackbot/src/smart_trade/mod.rs
+++ b/jackbot/src/smart_trade/mod.rs
@@ -1,0 +1,18 @@
+use rust_decimal::Decimal;
+
+pub mod trailing_take_profit;
+pub mod profit_target;
+pub mod trailing_stop;
+pub mod multi_level_stop;
+
+pub use trailing_take_profit::TrailingTakeProfit;
+pub use profit_target::ProfitTarget;
+pub use trailing_stop::TrailingStop;
+pub use multi_level_stop::MultiLevelStop;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SmartTradeSignal {
+    TakeProfit(Decimal),
+    StopLoss(Decimal),
+    StopLevel(usize, Decimal),
+}

--- a/jackbot/src/smart_trade/multi_level_stop.rs
+++ b/jackbot/src/smart_trade/multi_level_stop.rs
@@ -1,0 +1,27 @@
+use rust_decimal::Decimal;
+use crate::smart_trade::SmartTradeSignal;
+
+#[derive(Debug, Clone)]
+pub struct MultiLevelStop {
+    levels: Vec<Decimal>,
+    current: usize,
+}
+
+impl MultiLevelStop {
+    pub fn new(mut levels: Vec<Decimal>) -> Self {
+        levels.sort_by(|a, b| b.cmp(a));
+        Self { levels, current: 0 }
+    }
+
+    pub fn update(&mut self, price: Decimal) -> Option<SmartTradeSignal> {
+        if self.current >= self.levels.len() {
+            return None;
+        }
+        while self.current < self.levels.len() && price <= self.levels[self.current] {
+            let idx = self.current;
+            self.current += 1;
+            return Some(SmartTradeSignal::StopLevel(idx, price));
+        }
+        None
+    }
+}

--- a/jackbot/src/smart_trade/profit_target.rs
+++ b/jackbot/src/smart_trade/profit_target.rs
@@ -1,0 +1,23 @@
+use rust_decimal::Decimal;
+use crate::smart_trade::SmartTradeSignal;
+
+#[derive(Debug, Clone)]
+pub struct ProfitTarget {
+    target: Decimal,
+    triggered: bool,
+}
+
+impl ProfitTarget {
+    pub fn new(target: Decimal) -> Self {
+        Self { target, triggered: false }
+    }
+
+    pub fn update(&mut self, price: Decimal) -> Option<SmartTradeSignal> {
+        if !self.triggered && price >= self.target {
+            self.triggered = true;
+            Some(SmartTradeSignal::TakeProfit(price))
+        } else {
+            None
+        }
+    }
+}

--- a/jackbot/src/smart_trade/trailing_stop.rs
+++ b/jackbot/src/smart_trade/trailing_stop.rs
@@ -1,0 +1,34 @@
+use rust_decimal::Decimal;
+use crate::smart_trade::SmartTradeSignal;
+
+#[derive(Debug, Clone)]
+pub struct TrailingStop {
+    trailing: Decimal,
+    highest: Option<Decimal>,
+    triggered: bool,
+}
+
+impl TrailingStop {
+    pub fn new(trailing: Decimal) -> Self {
+        Self { trailing, highest: None, triggered: false }
+    }
+
+    pub fn update(&mut self, price: Decimal) -> Option<SmartTradeSignal> {
+        if self.triggered {
+            return None;
+        }
+        match self.highest {
+            Some(high) => {
+                if price > high {
+                    self.highest = Some(price);
+                }
+                if price <= high - self.trailing {
+                    self.triggered = true;
+                    return Some(SmartTradeSignal::StopLoss(price));
+                }
+            }
+            None => self.highest = Some(price),
+        }
+        None
+    }
+}

--- a/jackbot/src/smart_trade/trailing_take_profit.rs
+++ b/jackbot/src/smart_trade/trailing_take_profit.rs
@@ -1,0 +1,34 @@
+use rust_decimal::Decimal;
+use crate::smart_trade::SmartTradeSignal;
+
+#[derive(Debug, Clone)]
+pub struct TrailingTakeProfit {
+    trailing: Decimal,
+    highest: Option<Decimal>,
+    triggered: bool,
+}
+
+impl TrailingTakeProfit {
+    pub fn new(trailing: Decimal) -> Self {
+        Self { trailing, highest: None, triggered: false }
+    }
+
+    pub fn update(&mut self, price: Decimal) -> Option<SmartTradeSignal> {
+        if self.triggered {
+            return None;
+        }
+        match self.highest {
+            Some(high) => {
+                if price > high {
+                    self.highest = Some(price);
+                }
+                if price <= high - self.trailing {
+                    self.triggered = true;
+                    return Some(SmartTradeSignal::TakeProfit(price));
+                }
+            }
+            None => self.highest = Some(price),
+        }
+        None
+    }
+}

--- a/jackbot/tests/test_smart_trades.rs
+++ b/jackbot/tests/test_smart_trades.rs
@@ -1,0 +1,41 @@
+use Jackbot::smart_trade::{
+    TrailingTakeProfit, ProfitTarget, TrailingStop, MultiLevelStop, SmartTradeSignal,
+};
+use rust_decimal_macros::dec;
+
+#[test]
+fn test_trailing_take_profit() {
+    let mut tp = TrailingTakeProfit::new(dec!(10));
+    assert_eq!(tp.update(dec!(100)), None);
+    assert_eq!(tp.update(dec!(110)), None);
+    assert_eq!(tp.update(dec!(105)), None);
+    assert_eq!(tp.update(dec!(99)), Some(SmartTradeSignal::TakeProfit(dec!(99))));
+    assert_eq!(tp.update(dec!(101)), None);
+}
+
+#[test]
+fn test_profit_target() {
+    let mut pt = ProfitTarget::new(dec!(150));
+    assert_eq!(pt.update(dec!(140)), None);
+    assert_eq!(pt.update(dec!(150)), Some(SmartTradeSignal::TakeProfit(dec!(150))));
+    assert_eq!(pt.update(dec!(160)), None);
+}
+
+#[test]
+fn test_trailing_stop() {
+    let mut ts = TrailingStop::new(dec!(5));
+    assert_eq!(ts.update(dec!(100)), None);
+    assert_eq!(ts.update(dec!(110)), None);
+    assert_eq!(ts.update(dec!(104)), None);
+    assert_eq!(ts.update(dec!(103)), Some(SmartTradeSignal::StopLoss(dec!(103))));
+    assert_eq!(ts.update(dec!(120)), None);
+}
+
+#[test]
+fn test_multi_level_stop() {
+    let mut ms = MultiLevelStop::new(vec![dec!(90), dec!(80)]);
+    assert_eq!(ms.update(dec!(100)), None);
+    assert_eq!(ms.update(dec!(89)), Some(SmartTradeSignal::StopLevel(0, dec!(89))));
+    assert_eq!(ms.update(dec!(79)), Some(SmartTradeSignal::StopLevel(1, dec!(79))));
+    assert_eq!(ms.update(dec!(70)), None);
+}


### PR DESCRIPTION
## Summary
- implement basic smart trade modules (trailing take profit, profit target, trailing stop, multi-level stop)
- re-export smart trade module from library
- add unit tests for each smart trade type

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*