### PR TITLE
Add trade modules per exchange

### DIFF
--- a/jackbot-data/src/exchange/binance/futures/mod.rs
+++ b/jackbot-data/src/exchange/binance/futures/mod.rs
@@ -17,6 +17,8 @@ use std::fmt::{Display, Formatter};
 
 /// Level 2 OrderBook types.
 pub mod l2;
+/// Trade types.
+pub mod trade;
 
 /// Liquidation types.
 pub mod liquidation;

--- a/jackbot-data/src/exchange/binance/futures/trade.rs
+++ b/jackbot-data/src/exchange/binance/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Binance Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/binance/spot/mod.rs
+++ b/jackbot-data/src/exchange/binance/spot/mod.rs
@@ -15,6 +15,8 @@ use std::fmt::{Display, Formatter};
 
 /// Level 2 OrderBook types.
 pub mod l2;
+/// Trade types.
+pub mod trade;
 
 /// [`BinanceSpot`] WebSocket server base url.
 ///

--- a/jackbot-data/src/exchange/binance/spot/trade.rs
+++ b/jackbot-data/src/exchange/binance/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Binance Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/bitget/futures/mod.rs
+++ b/jackbot-data/src/exchange/bitget/futures/mod.rs
@@ -1,5 +1,6 @@
 //! Futures market types and operations for Bitget exchange
 pub mod l2;
+pub mod trade;
 
 use jackbot_instrument::exchange::ExchangeId;
 

--- a/jackbot-data/src/exchange/bitget/futures/trade.rs
+++ b/jackbot-data/src/exchange/bitget/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Bitget Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/bitget/spot/mod.rs
+++ b/jackbot-data/src/exchange/bitget/spot/mod.rs
@@ -1,5 +1,6 @@
 //! Spot market types and operations for Bitget exchange
 pub mod l2;
+pub mod trade;
 
 use jackbot_instrument::exchange::ExchangeId;
 

--- a/jackbot-data/src/exchange/bitget/spot/trade.rs
+++ b/jackbot-data/src/exchange/bitget/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Bitget Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/bybit/futures/mod.rs
+++ b/jackbot-data/src/exchange/bybit/futures/mod.rs
@@ -13,6 +13,9 @@ pub mod liquidation;
 /// L2 order book implementation
 pub mod l2;
 
+/// Trade types.
+pub mod trade;
+
 /// [`BybitPerpetualsUsd`] WebSocket server base url.
 ///
 /// See docs: <https://bybit-exchange.github.io/docs/v5/ws/connect>

--- a/jackbot-data/src/exchange/bybit/futures/trade.rs
+++ b/jackbot-data/src/exchange/bybit/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Bybit Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/bybit/spot/mod.rs
+++ b/jackbot-data/src/exchange/bybit/spot/mod.rs
@@ -9,6 +9,7 @@ pub const WEBSOCKET_BASE_URL_BYBIT_SPOT: &str = "wss://stream.bybit.com/v5/publi
 
 // L2 order book implementation
 pub mod l2;
+pub mod trade;
 
 /// [`Bybit`] spot execution.
 pub type BybitSpot = Bybit<BybitServerSpot>;

--- a/jackbot-data/src/exchange/bybit/spot/trade.rs
+++ b/jackbot-data/src/exchange/bybit/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Bybit Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/coinbase/spot/mod.rs
+++ b/jackbot-data/src/exchange/coinbase/spot/mod.rs
@@ -1,1 +1,2 @@
 pub mod l2;
+pub mod trade;

--- a/jackbot-data/src/exchange/coinbase/spot/trade.rs
+++ b/jackbot-data/src/exchange/coinbase/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Coinbase Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/hyperliquid/futures/mod.rs
+++ b/jackbot-data/src/exchange/hyperliquid/futures/mod.rs
@@ -1,3 +1,5 @@
 //! Futures market modules for Hyperliquid.
 //
 // Not yet implemented. This is a stub for future expansion.
+
+pub mod trade;

--- a/jackbot-data/src/exchange/hyperliquid/futures/trade.rs
+++ b/jackbot-data/src/exchange/hyperliquid/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Hyperliquid Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/hyperliquid/spot/mod.rs
+++ b/jackbot-data/src/exchange/hyperliquid/spot/mod.rs
@@ -1,3 +1,4 @@
 //! Spot market order book modules for Hyperliquid.
 
 pub mod l2;
+pub mod trade;

--- a/jackbot-data/src/exchange/hyperliquid/spot/trade.rs
+++ b/jackbot-data/src/exchange/hyperliquid/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Hyperliquid Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/kraken/futures/mod.rs
+++ b/jackbot-data/src/exchange/kraken/futures/mod.rs
@@ -1,6 +1,7 @@
 //! Futures market modules for Kraken.
 
 pub mod l2;
+pub mod trade;
 
 pub use l2::{
     KrakenFuturesOrderBookL2, KrakenFuturesOrderBooksL2SnapshotFetcher,

--- a/jackbot-data/src/exchange/kraken/futures/trade.rs
+++ b/jackbot-data/src/exchange/kraken/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Kraken Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/kraken/spot/mod.rs
+++ b/jackbot-data/src/exchange/kraken/spot/mod.rs
@@ -1,3 +1,4 @@
 //! Spot market order book modules for Kraken.
 
 pub mod l2;
+pub mod trade;

--- a/jackbot-data/src/exchange/kraken/spot/trade.rs
+++ b/jackbot-data/src/exchange/kraken/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Kraken Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/kucoin/futures/mod.rs
+++ b/jackbot-data/src/exchange/kucoin/futures/mod.rs
@@ -1,3 +1,5 @@
 //! Futures market modules for Kucoin.
 //
 // Not yet implemented. This is a stub for future expansion.
+
+pub mod trade;

--- a/jackbot-data/src/exchange/kucoin/futures/trade.rs
+++ b/jackbot-data/src/exchange/kucoin/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Kucoin Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/kucoin/spot/mod.rs
+++ b/jackbot-data/src/exchange/kucoin/spot/mod.rs
@@ -1,3 +1,4 @@
 //! Spot market order book modules for Kucoin.
 
 pub mod l2;
+pub mod trade;

--- a/jackbot-data/src/exchange/kucoin/spot/trade.rs
+++ b/jackbot-data/src/exchange/kucoin/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Kucoin Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/okx/futures/mod.rs
+++ b/jackbot-data/src/exchange/okx/futures/mod.rs
@@ -1,1 +1,2 @@
 pub mod l2;
+pub mod trade;

--- a/jackbot-data/src/exchange/okx/futures/trade.rs
+++ b/jackbot-data/src/exchange/okx/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Okx Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/okx/spot/mod.rs
+++ b/jackbot-data/src/exchange/okx/spot/mod.rs
@@ -1,1 +1,2 @@
 pub mod l2;
+pub mod trade;

--- a/jackbot-data/src/exchange/okx/spot/trade.rs
+++ b/jackbot-data/src/exchange/okx/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Trade event types for Okx Spot.
+
+pub use super::super::trade::*;


### PR DESCRIPTION
## Summary
- scaffold spot and futures trade modules for each exchange
- re-export existing trade logic from new modules

## Testing
- `cargo test -p jackbot-data --locked --offline` *(fails: no matching package named `chrono` found)*