### PR TITLE
Add strategy framework and TA utilities

### DIFF
--- a/docs/STRATEGY_FRAMEWORK.md
+++ b/docs/STRATEGY_FRAMEWORK.md
@@ -1,0 +1,49 @@
+# Jackbot Strategy Framework
+
+This document provides a brief overview of the strategy utilities added to Jackbot.
+
+## Strategy Abstraction
+
+`strategy::framework::Strategy` combines the existing `AlgoStrategy` and
+`ClosePositionsStrategy` traits. Strategies implementing this trait expose an
+`id` method for registry lookups.
+
+## Strategy Registry
+
+`strategy::registry::StrategyRegistry` offers a lightweight container for
+storing strategies keyed by `StrategyId`. It provides simple `register`, `get`
+and `remove` helpers so strategies can be discovered dynamically.
+
+## Technical Analysis Library
+
+The `technical` module implements a few basic indicators used across example
+strategies:
+
+- `sma` – Simple moving average
+- `ema` – Exponential moving average
+- `rsi` – Relative strength index
+
+These functions operate on `f64` slices and return a `Vec<f64>` containing the
+indicator values.
+
+## Machine Learning Model Integration
+
+The `ml` module provides a minimal `Model` trait and a serialisable
+`LinearModel`. Models can be loaded from JSON and used to generate predictions
+inside strategies.
+
+## Configuration Management
+
+`strategy::config::StrategyConfig` is a simple structure for loading strategy
+parameters from JSON files. Parameters are stored in a `HashMap<String, f64>`
+for maximum flexibility.
+
+## A/B Testing
+
+`ab_testing::ab_test` runs two strategies sequentially using the existing
+backtesting infrastructure and returns a pair of summaries for comparison.
+
+## Examples
+
+See `examples/sma_crossover.rs` for a very small demonstration strategy using
+these utilities.

--- a/jackbot/examples/sma_crossover.rs
+++ b/jackbot/examples/sma_crossover.rs
@@ -1,0 +1,16 @@
+use Jackbot::strategy::{framework::Strategy, registry::StrategyRegistry, DefaultStrategy};
+use Jackbot::technical::{sma, ema, rsi};
+use jackbot_execution::order::id::StrategyId;
+
+fn main() {
+    let data = vec![1.0,2.0,3.0,4.0,5.0,6.0,7.0];
+    let short = sma(3, &data);
+    let long = sma(5, &data);
+    println!("short SMA: {:?}", short);
+    println!("long SMA: {:?}", long);
+
+    let mut registry = StrategyRegistry::new();
+    let strat = DefaultStrategy::<()>::default();
+    registry.register(strat.id.clone(), strat);
+    println!("registered strategies: {}", registry.into_iter().count());
+}

--- a/jackbot/src/ab_testing.rs
+++ b/jackbot/src/ab_testing.rs
@@ -1,0 +1,83 @@
+use crate::backtest::{backtest, BacktestArgsConstant, BacktestArgsDynamic, BacktestSummary};
+use crate::engine::state::EngineState;
+use crate::error::JackbotError;
+use std::sync::Arc;
+
+pub async fn ab_test<MD, SI, SA, SB, Risk, GD, ID>(
+    args: Arc<BacktestArgsConstant<MD, SI, EngineState<GD, ID>>>,
+    strategy_a: BacktestArgsDynamic<SA, Risk>,
+    strategy_b: BacktestArgsDynamic<SB, Risk>,
+) -> Result<(BacktestSummary<SI>, BacktestSummary<SI>), JackbotError>
+where
+    MD: crate::backtest::market_data::BacktestMarketData<Kind = ID::MarketEventKind>,
+    SI: crate::statistic::time::TimeInterval,
+    SA: crate::strategy::algo::AlgoStrategy<State = EngineState<GD, ID>>
+        + crate::strategy::close_positions::ClosePositionsStrategy<State = EngineState<GD, ID>>
+        + crate::strategy::on_trading_disabled::OnTradingDisabled<
+            crate::engine::clock::HistoricalClock,
+            EngineState<GD, ID>,
+            crate::execution::execution_tx::MultiExchangeTxMap,
+            Risk,
+        >
+        + crate::strategy::on_disconnect::OnDisconnectStrategy<
+            crate::engine::clock::HistoricalClock,
+            EngineState<GD, ID>,
+            crate::execution::execution_tx::MultiExchangeTxMap,
+            Risk,
+        >
+        + Send
+        + 'static,
+    <SA as crate::strategy::on_trading_disabled::OnTradingDisabled<
+        crate::engine::clock::HistoricalClock,
+        EngineState<GD, ID>,
+        crate::execution::execution_tx::MultiExchangeTxMap,
+        Risk,
+    >>::OnTradingDisabled: std::fmt::Debug + Clone + Send,
+    <SA as crate::strategy::on_disconnect::OnDisconnectStrategy<
+        crate::engine::clock::HistoricalClock,
+        EngineState<GD, ID>,
+        crate::execution::execution_tx::MultiExchangeTxMap,
+        Risk,
+    >>::OnDisconnect: std::fmt::Debug + Clone + Send,
+    SB: crate::strategy::algo::AlgoStrategy<State = EngineState<GD, ID>>
+        + crate::strategy::close_positions::ClosePositionsStrategy<State = EngineState<GD, ID>>
+        + crate::strategy::on_trading_disabled::OnTradingDisabled<
+            crate::engine::clock::HistoricalClock,
+            EngineState<GD, ID>,
+            crate::execution::execution_tx::MultiExchangeTxMap,
+            Risk,
+        >
+        + crate::strategy::on_disconnect::OnDisconnectStrategy<
+            crate::engine::clock::HistoricalClock,
+            EngineState<GD, ID>,
+            crate::execution::execution_tx::MultiExchangeTxMap,
+            Risk,
+        >
+        + Send
+        + 'static,
+    <SB as crate::strategy::on_trading_disabled::OnTradingDisabled<
+        crate::engine::clock::HistoricalClock,
+        EngineState<GD, ID>,
+        crate::execution::execution_tx::MultiExchangeTxMap,
+        Risk,
+    >>::OnTradingDisabled: std::fmt::Debug + Clone + Send,
+    <SB as crate::strategy::on_disconnect::OnDisconnectStrategy<
+        crate::engine::clock::HistoricalClock,
+        EngineState<GD, ID>,
+        crate::execution::execution_tx::MultiExchangeTxMap,
+        Risk,
+    >>::OnDisconnect: std::fmt::Debug + Clone + Send,
+    Risk: crate::risk::RiskManager<State = EngineState<GD, ID>> + Send + 'static,
+    GD: for<'a> crate::engine::Processor<&'a crate::data::event::MarketEvent<crate::instrument::instrument::InstrumentIndex, ID::MarketEventKind>>
+        + for<'a> crate::engine::Processor<&'a crate::execution::AccountEvent>
+        + std::fmt::Debug
+        + Clone
+        + Default
+        + Send
+        + 'static,
+    ID: crate::engine::state::instrument::data::InstrumentDataState + Send + 'static,
+{
+    let res_a = backtest(Arc::clone(&args), strategy_a).await?;
+    let res_b = backtest(args, strategy_b).await?;
+    Ok((res_a, res_b))
+}

--- a/jackbot/src/lib.rs
+++ b/jackbot/src/lib.rs
@@ -87,6 +87,15 @@ pub mod system;
 /// Backtesting utilities.
 pub mod backtest;
 
+/// Lightweight A/B testing utilities built on top of the backtester.
+pub mod ab_testing;
+
+/// Basic technical analysis indicators.
+pub mod technical;
+
+/// Simple machine learning model trait and implementations.
+pub mod ml;
+
 /// Traits and types related to component shutdowns.
 pub mod shutdown;
 

--- a/jackbot/src/ml.rs
+++ b/jackbot/src/ml.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use std::{fs::File, path::Path};
+
+pub trait Model {
+    fn predict(&self, features: &[f64]) -> f64;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinearModel {
+    pub weights: Vec<f64>,
+    pub bias: f64,
+}
+
+impl Model for LinearModel {
+    fn predict(&self, features: &[f64]) -> f64 {
+        self.weights
+            .iter()
+            .zip(features.iter())
+            .map(|(w, x)| w * x)
+            .sum::<f64>()
+            + self.bias
+    }
+}
+
+impl LinearModel {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, Box<dyn std::error::Error>> {
+        let file = File::open(path)?;
+        Ok(serde_json::from_reader(file)?)
+    }
+}

--- a/jackbot/src/strategy/config.rs
+++ b/jackbot/src/strategy/config.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs::File, path::Path};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StrategyConfig {
+    pub name: String,
+    #[serde(default)]
+    pub parameters: HashMap<String, f64>,
+}
+
+impl StrategyConfig {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, Box<dyn std::error::Error>> {
+        let file = File::open(path)?;
+        Ok(serde_json::from_reader(file)?)
+    }
+}

--- a/jackbot/src/strategy/framework.rs
+++ b/jackbot/src/strategy/framework.rs
@@ -1,0 +1,11 @@
+use crate::strategy::{algo::AlgoStrategy, close_positions::ClosePositionsStrategy};
+use jackbot_execution::order::id::StrategyId;
+use jackbot_instrument::{asset::AssetIndex, exchange::ExchangeIndex, instrument::InstrumentIndex};
+
+pub trait Strategy<E = ExchangeIndex, I = InstrumentIndex>:
+    AlgoStrategy<E, I, State = Self::State> +
+    ClosePositionsStrategy<E, AssetIndex, I, State = Self::State>
+{
+    type State;
+    fn id(&self) -> StrategyId;
+}

--- a/jackbot/src/strategy/mod.rs
+++ b/jackbot/src/strategy/mod.rs
@@ -12,6 +12,7 @@ use crate::{
         on_disconnect::OnDisconnectStrategy,
         on_trading_disabled::OnTradingDisabled,
     },
+    strategy::framework,
 };
 use jackbot_execution::order::{
     id::{ClientOrderId, StrategyId},
@@ -39,6 +40,15 @@ pub mod on_disconnect;
 /// Defines a strategy interface enables custom [`Engine`] to be performed in the event that the
 /// `TradingState` gets set to `TradingState::Disabled`.
 pub mod on_trading_disabled;
+
+/// Strategy trait combining the core strategy interfaces.
+pub mod framework;
+
+/// Registry for storing and retrieving strategies by [`StrategyId`].
+pub mod registry;
+
+/// Loadable strategy configuration.
+pub mod config;
 
 /// Naive implementation of all strategy interfaces.
 ///
@@ -126,5 +136,13 @@ impl<Clock, State, ExecutionTxs, Risk> OnTradingDisabled<Clock, State, Execution
     fn on_trading_disabled(
         _: &mut Engine<Clock, State, ExecutionTxs, Self, Risk>,
     ) -> Self::OnTradingDisabled {
+    }
+}
+
+impl<State> framework::Strategy for DefaultStrategy<State> {
+    type State = State;
+
+    fn id(&self) -> StrategyId {
+        self.id.clone()
     }
 }

--- a/jackbot/src/strategy/registry.rs
+++ b/jackbot/src/strategy/registry.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+use jackbot_execution::order::id::StrategyId;
+
+#[derive(Debug, Default)]
+pub struct StrategyRegistry<S> {
+    strategies: HashMap<StrategyId, S>,
+}
+
+impl<S> StrategyRegistry<S> {
+    pub fn new() -> Self {
+        Self { strategies: HashMap::new() }
+    }
+
+    pub fn register(&mut self, id: StrategyId, strategy: S) {
+        self.strategies.insert(id, strategy);
+    }
+
+    pub fn get(&self, id: &StrategyId) -> Option<&S> {
+        self.strategies.get(id)
+    }
+
+    pub fn get_mut(&mut self, id: &StrategyId) -> Option<&mut S> {
+        self.strategies.get_mut(id)
+    }
+
+    pub fn remove(&mut self, id: &StrategyId) -> Option<S> {
+        self.strategies.remove(id)
+    }
+}
+
+impl<S> IntoIterator for StrategyRegistry<S> {
+    type Item = (StrategyId, S);
+    type IntoIter = std::collections::hash_map::IntoIter<StrategyId, S>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.strategies.into_iter()
+    }
+}

--- a/jackbot/src/technical/mod.rs
+++ b/jackbot/src/technical/mod.rs
@@ -1,0 +1,57 @@
+pub fn sma(period: usize, data: &[f64]) -> Vec<f64> {
+    if period == 0 || data.len() < period {
+        return Vec::new();
+    }
+    data.windows(period)
+        .map(|w| w.iter().sum::<f64>() / period as f64)
+        .collect()
+}
+
+pub fn ema(period: usize, data: &[f64]) -> Vec<f64> {
+    if period == 0 || data.is_empty() {
+        return Vec::new();
+    }
+    let k = 2.0 / (period as f64 + 1.0);
+    let mut out = Vec::with_capacity(data.len());
+    let mut ema_prev = data[0];
+    out.push(ema_prev);
+    for &val in &data[1..] {
+        ema_prev = val * k + ema_prev * (1.0 - k);
+        out.push(ema_prev);
+    }
+    out
+}
+
+pub fn rsi(period: usize, data: &[f64]) -> Vec<f64> {
+    if period == 0 || data.len() <= period {
+        return Vec::new();
+    }
+    let mut gains = 0.0;
+    let mut losses = 0.0;
+    for i in 1..=period {
+        let diff = data[i] - data[i - 1];
+        if diff >= 0.0 {
+            gains += diff;
+        } else {
+            losses -= diff;
+        }
+    }
+    let mut avg_gain = gains / period as f64;
+    let mut avg_loss = losses / period as f64;
+    let mut out = Vec::with_capacity(data.len() - period);
+    let mut rs = if avg_loss == 0.0 { f64::INFINITY } else { avg_gain / avg_loss };
+    out.push(100.0 - 100.0 / (1.0 + rs));
+    for i in period + 1..data.len() {
+        let diff = data[i] - data[i - 1];
+        if diff >= 0.0 {
+            avg_gain = (avg_gain * (period as f64 - 1.0) + diff) / period as f64;
+            avg_loss = (avg_loss * (period as f64 - 1.0)) / period as f64;
+        } else {
+            avg_gain = (avg_gain * (period as f64 - 1.0)) / period as f64;
+            avg_loss = (avg_loss * (period as f64 - 1.0) - diff) / period as f64;
+        }
+        rs = if avg_loss == 0.0 { f64::INFINITY } else { avg_gain / avg_loss };
+        out.push(100.0 - 100.0 / (1.0 + rs));
+    }
+    out
+}

--- a/jackbot/tests/test_strategy_registry.rs
+++ b/jackbot/tests/test_strategy_registry.rs
@@ -1,0 +1,13 @@
+use Jackbot::strategy::{registry::StrategyRegistry, DefaultStrategy};
+use jackbot_execution::order::id::StrategyId;
+
+#[test]
+fn test_register_and_get() {
+    let mut reg = StrategyRegistry::new();
+    let strat: DefaultStrategy<()> = DefaultStrategy::default();
+    let id = strat.id.clone();
+    reg.register(id.clone(), strat);
+    assert!(reg.get(&id).is_some());
+    assert!(reg.remove(&id).is_some());
+    assert!(reg.get(&id).is_none());
+}

--- a/jackbot/tests/test_technical.rs
+++ b/jackbot/tests/test_technical.rs
@@ -1,0 +1,23 @@
+use Jackbot::technical::{sma, ema, rsi};
+
+#[test]
+fn test_sma() {
+    let data = [1.0, 2.0, 3.0, 4.0, 5.0];
+    let sma3 = sma(3, &data);
+    assert_eq!(sma3, vec![2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn test_ema() {
+    let data = [1.0, 2.0, 3.0];
+    let ema2 = ema(2, &data);
+    assert_eq!(ema2.len(), 3);
+    assert!((ema2[0] - 1.0).abs() < 1e-8);
+}
+
+#[test]
+fn test_rsi() {
+    let data = [1.0, 2.0, 3.0, 2.5, 2.0, 3.0];
+    let r = rsi(2, &data);
+    assert_eq!(r.len(), data.len() - 2);
+}


### PR DESCRIPTION
## Summary
- add basic technical analysis functions (sma/ema/rsi)
- implement strategy registry and shared Strategy trait
- provide ML model integration skeleton
- offer config loader for strategy parameters
- add A/B testing helper and example strategy
- document new strategy framework
- add unit tests for registry and technical indicators

## Testing
- `cargo test --workspace --quiet` *(fails: failed to download crates)*