### PR TITLE
Add strategy trait crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,10 @@ members = [
     "jackbot-execution",
     "jackbot-integration",
     "jackbot-macro", 
-    "jackbot-instrument"
-, "jackbot-snapshot"]
+    "jackbot-instrument",
+    "jackbot-snapshot",
+    "jackbot-strategy",
+]
 
 [workspace.dependencies]
 # Jackbot Ecosystem
@@ -16,6 +18,7 @@ jackbot-instrument = { path = "./jackbot-instrument", version = "0.3.1" }
 jackbot-data = { path = "./jackbot-data", version = "0.10.1" }
 jackbot-execution = { path = "./jackbot-execution", version = "0.5.3" }
 jackbot-macro = { path = "./jackbot-macro", version = "0.2.0" }
+jackbot-strategy = { path = "./jackbot-strategy", version = "0.1.0" }
 
 # Logging
 tracing = { version = "0.1.41" }

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -723,7 +723,7 @@ Exchanges currently implementing the `Canonicalizer` trait:
 - [x] Historical Data Loading Framework (Parquet, S3, multi-exchange, spot/futures)
 - [x] Order Book Replay Engine (timestamp-preserving, accurate sequencing)
 - [x] Market Simulation (realistic order execution, fees, slippage)
-- [ ] Strategy Interface (event-driven, configurable parameters)
+- [x] Strategy Interface (event-driven, configurable parameters)
 - [x] Performance Metrics (P&L, risk measures, trade statistics)
 - [x] Visualization and Reporting (charts, tables, exports)
 - [x] Parameter Optimization (grid search, genetic algorithms)
@@ -790,7 +790,7 @@ Exchanges currently implementing the `Canonicalizer` trait:
 
 **Feature-Specific TODOs:**
 
-- [ ] Strategy Interface Definition (inputs, outputs, events, lifecycle)
+- [x] Strategy Interface Definition (inputs, outputs, events, lifecycle)
 - [ ] Technical Analysis Library (indicators, patterns, signals)
 - [ ] ML Integration Framework (feature extraction, model loading, inference)
 - [ ] Strategy Configuration and Parameter Management

--- a/docs/STRATEGY_FRAMEWORK.md
+++ b/docs/STRATEGY_FRAMEWORK.md
@@ -8,6 +8,10 @@ This document provides a brief overview of the strategy utilities added to Jackb
 `ClosePositionsStrategy` traits. Strategies implementing this trait expose an
 `id` method for registry lookups.
 
+The standalone `jackbot-strategy` crate offers a lightweight `Strategy` trait
+with `on_start`, `on_event` and `on_stop` hooks for simple event driven
+strategies.
+
 ## Strategy Registry
 
 `strategy::registry::StrategyRegistry` offers a lightweight container for

--- a/jackbot-strategy/Cargo.toml
+++ b/jackbot-strategy/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "jackbot-strategy"
+version = "0.1.0"
+edition = "2024"
+authors = ["JustAStream <justastream.code@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+description = "Strategy trait and utilities for Jackbot"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }

--- a/jackbot-strategy/README.md
+++ b/jackbot-strategy/README.md
@@ -1,0 +1,3 @@
+# Jackbot Strategy
+
+Strategy trait and utilities for Jackbot.

--- a/jackbot-strategy/src/lib.rs
+++ b/jackbot-strategy/src/lib.rs
@@ -1,0 +1,57 @@
+//! Strategy trait and helpers for Jackbot.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Configuration parameters for a strategy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StrategyConfig {
+    #[serde(default)]
+    pub parameters: HashMap<String, f64>,
+}
+
+impl StrategyConfig {
+    /// Convenience helper to get a parameter by name.
+    pub fn get(&self, key: &str) -> Option<f64> {
+        self.parameters.get(key).copied()
+    }
+}
+
+/// Trait implemented by event-driven strategies.
+///
+/// Strategies receive events of type `E` and can react to lifecycle
+/// hooks such as `on_start` and `on_stop`.
+pub trait Strategy<E> {
+    /// Called once before the strategy begins processing events.
+    fn on_start(&mut self, _config: &StrategyConfig) {}
+
+    /// Handle a single event.
+    fn on_event(&mut self, event: &E);
+
+    /// Called when the strategy is shutting down.
+    fn on_stop(&mut self) {}
+}
+
+/// A simple strategy that records every event it receives.
+#[derive(Debug, Default)]
+pub struct RecordingStrategy<E> {
+    pub events: Vec<E>,
+}
+
+impl<E: Clone> Strategy<E> for RecordingStrategy<E> {
+    fn on_event(&mut self, event: &E) {
+        self.events.push(event.clone());
+    }
+}
+
+/// Strategy counting the number of processed events.
+#[derive(Debug, Default)]
+pub struct CountingStrategy {
+    pub count: usize,
+}
+
+impl<E> Strategy<E> for CountingStrategy {
+    fn on_event(&mut self, _event: &E) {
+        self.count += 1;
+    }
+}

--- a/jackbot-strategy/tests/dummy.rs
+++ b/jackbot-strategy/tests/dummy.rs
@@ -1,0 +1,20 @@
+use jackbot_strategy::{RecordingStrategy, CountingStrategy, Strategy, StrategyConfig};
+
+#[test]
+fn recording_strategy_collects_events() {
+    let mut strat = RecordingStrategy::default();
+    strat.on_start(&StrategyConfig { parameters: Default::default() });
+    strat.on_event(&1);
+    strat.on_event(&2);
+    strat.on_stop();
+    assert_eq!(strat.events, vec![1, 2]);
+}
+
+#[test]
+fn counting_strategy_counts_events() {
+    let mut strat = CountingStrategy::default();
+    for _ in 0..5 {
+        strat.on_event(&"event");
+    }
+    assert_eq!(strat.count, 5);
+}


### PR DESCRIPTION
## Summary
- add new `jackbot-strategy` crate
- implement `Strategy` trait with lifecycle hooks and config
- provide example strategies and tests
- document new crate and mark related status items complete

## Testing
- `cargo test --workspace` *(fails: Could not connect to server)*