### PR TITLE
Implement Kucoin rate limiter with jitter backoff

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -687,7 +687,8 @@ Exchanges currently implementing the `Canonicalizer` trait:
 - [ ] Bybit: Implement/refactor rate limiting for REST/WebSocket (spot/futures).
 - [ ] Coinbase: Implement/refactor rate limiting for REST/WebSocket (spot/futures).
 - [ ] Kraken: Implement/refactor rate limiting for REST/WebSocket (spot/futures).
-- [ ] Kucoin: Implement/refactor rate limiting for REST/WebSocket (spot/futures).
+- [x] Kucoin: Rate limiting implemented for REST (30 req/3s) and WebSocket (100 msgs/10s) with adaptive jittered backoff.
+- Kucoin REST quota: 30 requests/3s per IP. WebSocket quota: 100 messages/10s.
 - [ ] OKX: Implement/refactor rate limiting for REST/WebSocket (spot/futures).
 - [ ] Hyperliquid: Implement/refactor rate limiting for REST/WebSocket (spot/futures).
 - [ ] MEXC: Implement/refactor rate limiting for REST/WebSocket (spot/futures).

--- a/jackbot-data/src/exchange/kucoin/mod.rs
+++ b/jackbot-data/src/exchange/kucoin/mod.rs
@@ -30,6 +30,7 @@ pub mod market;
 pub mod spot;
 pub mod subscription;
 pub mod trade;
+pub mod rate_limit;
 
 /// Kucoin WebSocket base URL.
 pub const BASE_URL_KUCOIN: &str = "wss://ws-api.kucoin.com/endpoint";

--- a/jackbot-data/src/exchange/kucoin/rate_limit.rs
+++ b/jackbot-data/src/exchange/kucoin/rate_limit.rs
@@ -1,0 +1,87 @@
+use jackbot_integration::rate_limit::{Priority, RateLimiter};
+use std::time::Duration;
+
+/// Kucoin API rate limiter for REST and WebSocket usage.
+#[derive(Clone)]
+pub struct KucoinRateLimit {
+    rest: RateLimiter,
+    ws: RateLimiter,
+}
+
+impl KucoinRateLimit {
+    /// Create a new [`KucoinRateLimit`] using official exchange quotas.
+    ///
+    /// REST: 30 requests per 3 seconds per IP.
+    /// WebSocket: 100 messages per 10 seconds.
+    pub fn new() -> Self {
+        Self::with_params(
+            30,
+            Duration::from_secs(3),
+            100,
+            Duration::from_secs(10),
+            Duration::from_millis(100),
+        )
+    }
+
+    /// Create a custom [`KucoinRateLimit`] with provided quotas and jitter for testing.
+    pub fn with_params(
+        rest_capacity: usize,
+        rest_interval: Duration,
+        ws_capacity: usize,
+        ws_interval: Duration,
+        jitter: Duration,
+    ) -> Self {
+        Self {
+            rest: RateLimiter::new_with_jitter(rest_capacity, rest_interval, jitter),
+            ws: RateLimiter::new_with_jitter(ws_capacity, ws_interval, jitter),
+        }
+    }
+
+    /// Acquire a REST permit with the specified [`Priority`].
+    pub async fn acquire_rest(&self, priority: Priority) {
+        self.rest.acquire(priority).await;
+    }
+
+    /// Acquire a WebSocket permit with the specified [`Priority`].
+    pub async fn acquire_ws(&self, priority: Priority) {
+        self.ws.acquire(priority).await;
+    }
+
+    /// Report a REST rate limit violation.
+    pub async fn report_rest_violation(&self) {
+        self.rest.report_violation().await;
+    }
+
+    /// Report a WebSocket rate limit violation.
+    pub async fn report_ws_violation(&self) {
+        self.ws.report_violation().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackbot_integration::rate_limit::Priority;
+    use tokio::time::{Instant, Duration};
+
+    #[tokio::test]
+    async fn test_rest_limit_exhaustion() {
+        let rl = KucoinRateLimit::with_params(1, Duration::from_millis(40), 1, Duration::from_millis(40), Duration::from_millis(0));
+        rl.acquire_rest(Priority::Normal).await;
+        let start = Instant::now();
+        rl.acquire_rest(Priority::Normal).await;
+        assert!(start.elapsed() >= Duration::from_millis(40));
+    }
+
+    #[tokio::test]
+    async fn test_ws_backoff_jitter() {
+        let rl = KucoinRateLimit::with_params(1, Duration::from_millis(20), 1, Duration::from_millis(20), Duration::from_millis(20));
+        rl.acquire_ws(Priority::Normal).await;
+        rl.report_ws_violation().await; // next interval 40-60ms
+        let start = Instant::now();
+        rl.acquire_ws(Priority::Normal).await;
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(40));
+        assert!(elapsed <= Duration::from_millis(60));
+    }
+}


### PR DESCRIPTION
## Summary
- add jittered adaptive rate limiting primitives
- provide Kucoin-specific rate limiter for REST and WS
- document Kucoin quotas

## Testing
- `cargo test --workspace --quiet` *(fails: failed to download from crates.io)*