### PR TITLE
Implement Binance trade WS listeners

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -167,9 +167,9 @@ Exchanges currently implementing the `Canonicalizer` trait:
 **Exchange-Specific TODOs:**
 
 - **Binance**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **Bitget**
   - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).

--- a/jackbot-data/src/exchange/binance/futures/trade.rs
+++ b/jackbot-data/src/exchange/binance/futures/trade.rs
@@ -1,3 +1,79 @@
-//! Trade event types for Binance Futures.
+//! Public trade stream types for Binance Futures.
+//!
+//! This module exposes a [`StatelessTransformer`](crate::transformer::stateless::StatelessTransformer)
+//! based implementation for transforming raw Binance Futures trade messages into
+//! normalised [`MarketEvent`](crate::event::MarketEvent)s.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::BinanceFuturesUsd;
+
+pub use super::super::trade::BinanceTrade;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Binance Futures WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type BinanceFuturesTradesTransformer<InstrumentKey> =
+    StatelessTransformer<BinanceFuturesUsd, InstrumentKey, PublicTrades, BinanceTrade>;
+
+/// Type alias for a Binance Futures trades WebSocket stream.
+pub type BinanceFuturesTradesStream<InstrumentKey> =
+    ExchangeWsStream<BinanceFuturesTradesTransformer<InstrumentKey>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        event::MarketEvent,
+        subscription::Map,
+        transformer::ExchangeTransformer,
+    };
+    use fnv::FnvHashMap;
+    use jackbot_instrument::Side;
+    use jackbot_integration::subscription::SubscriptionId;
+    use tokio::sync::mpsc;
+
+    fn example_trade_json() -> &'static str {
+        r#"{
+            "e":"trade","E":1649324825173,"s":"ETHUSDT","t":1000000000,
+            "p":"10000.19","q":"0.239000","b":10108767791,"a":10108764858,
+            "T":1749354825200,"m":true,"M":true
+        }"#
+    }
+
+    #[tokio::test]
+    async fn test_transformer_success() {
+        let sub_id = SubscriptionId::from("@trade|ETHUSDT");
+        let mut map = FnvHashMap::default();
+        map.insert(sub_id.clone(), "ETHUSDT".to_string());
+        let map = Map(map);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut transformer =
+            BinanceFuturesTradesTransformer::init(map, &[], tx).await.unwrap();
+
+        let trade: BinanceTrade = serde_json::from_str(example_trade_json()).unwrap();
+        let events = transformer.transform(trade);
+
+        assert_eq!(events.len(), 1);
+        let MarketEvent { kind, .. } = events.into_iter().next().unwrap().unwrap();
+        assert_eq!(kind.side, Side::Sell);
+    }
+
+    #[tokio::test]
+    async fn test_transformer_unidentifiable() {
+        let map = Map(FnvHashMap::<SubscriptionId, String>::default());
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut transformer =
+            BinanceFuturesTradesTransformer::init(map, &[], tx).await.unwrap();
+
+        let trade: BinanceTrade = serde_json::from_str(example_trade_json()).unwrap();
+        let events = transformer.transform(trade);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_err());
+    }
+}

--- a/jackbot-data/src/exchange/binance/spot/trade.rs
+++ b/jackbot-data/src/exchange/binance/spot/trade.rs
@@ -1,3 +1,83 @@
-//! Trade event types for Binance Spot.
+//! Public trade stream types for Binance Spot.
+//!
+//! This module exposes a [`StatelessTransformer`](crate::transformer::stateless::StatelessTransformer)
+//! based implementation for transforming raw Binance Spot trade messages into
+//! normalised [`MarketEvent`](crate::event::MarketEvent)s. It simply re-exports
+//! the common [`BinanceTrade`](super::super::trade::BinanceTrade) type and
+//! provides convenient type aliases for transformer and stream usage.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::BinanceSpot;
+
+pub use super::super::trade::BinanceTrade;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Binance Spot WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type BinanceSpotTradesTransformer<InstrumentKey> =
+    StatelessTransformer<BinanceSpot, InstrumentKey, PublicTrades, BinanceTrade>;
+
+/// Type alias for a Binance Spot trades WebSocket stream.
+pub type BinanceSpotTradesStream<InstrumentKey> =
+    ExchangeWsStream<BinanceSpotTradesTransformer<InstrumentKey>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        event::MarketEvent,
+        subscription::Map,
+        transformer::ExchangeTransformer,
+    };
+    use fnv::FnvHashMap;
+    use jackbot_instrument::Side;
+    use jackbot_integration::subscription::SubscriptionId;
+    use tokio::sync::mpsc;
+
+    fn example_trade_json() -> &'static str {
+        r#"{
+            "e":"trade","E":1649324825173,"s":"ETHUSDT","t":1000000000,
+            "p":"10000.19","q":"0.239000","b":10108767791,"a":10108764858,
+            "T":1749354825200,"m":false,"M":true
+        }"#
+    }
+
+    #[tokio::test]
+    async fn test_transformer_success() {
+        let sub_id = SubscriptionId::from("@trade|ETHUSDT");
+        let mut map = FnvHashMap::default();
+        map.insert(sub_id.clone(), "ETHUSDT".to_string());
+        let map = Map(map);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut transformer =
+            BinanceSpotTradesTransformer::init(map, &[], tx).await.unwrap();
+
+        let trade: BinanceTrade = serde_json::from_str(example_trade_json()).unwrap();
+        let events = transformer.transform(trade);
+
+        assert_eq!(events.len(), 1);
+        let MarketEvent { kind, .. } = events.into_iter().next().unwrap().unwrap();
+        assert_eq!(kind.price, 10000.19);
+        assert_eq!(kind.amount, 0.239000);
+        assert_eq!(kind.side, Side::Buy);
+    }
+
+    #[tokio::test]
+    async fn test_transformer_unidentifiable() {
+        let map = Map(FnvHashMap::<SubscriptionId, String>::default());
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut transformer =
+            BinanceSpotTradesTransformer::init(map, &[], tx).await.unwrap();
+
+        let trade: BinanceTrade = serde_json::from_str(example_trade_json()).unwrap();
+        let events = transformer.transform(trade);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_err());
+    }
+}

--- a/jackbot-data/tests/binance_trades.rs
+++ b/jackbot-data/tests/binance_trades.rs
@@ -1,0 +1,38 @@
+use jackbot_data::exchange::{
+    binance::{channel::BinanceChannel, market::BinanceMarket, spot::BinanceSpot},
+    subscription::ExchangeSub,
+};
+use tokio_tungstenite::tungstenite::Message;
+
+#[test]
+fn test_binance_spot_trade_requests() {
+    let subs = vec![
+        ExchangeSub::from((BinanceChannel::TRADES, BinanceMarket("BTCUSDT".into()))),
+        ExchangeSub::from((BinanceChannel::TRADES, BinanceMarket("ETHUSDT".into()))),
+    ];
+
+    let msgs = BinanceSpot::requests(subs);
+    assert_eq!(msgs.len(), 1);
+    match &msgs[0] {
+        Message::Text(text) => {
+            let v: serde_json::Value = serde_json::from_str(text).unwrap();
+            assert_eq!(v["method"], "SUBSCRIBE");
+            assert_eq!(v["id"], 1);
+            assert_eq!(v["params"], serde_json::json!(["btcusdt@trade", "ethusdt@trade"]));
+        }
+        _ => panic!("expected text message"),
+    }
+}
+
+#[test]
+fn test_binance_spot_trade_requests_empty() {
+    let msgs = BinanceSpot::requests(Vec::<ExchangeSub<_, _>>::new());
+    assert_eq!(msgs.len(), 1);
+    match &msgs[0] {
+        Message::Text(text) => {
+            let v: serde_json::Value = serde_json::from_str(text).unwrap();
+            assert_eq!(v["params"].as_array().unwrap().len(), 0);
+        }
+        _ => panic!("expected text message"),
+    }
+}


### PR DESCRIPTION
## Summary
- add Spot/Futures trade stream transformers for Binance
- provide unit tests for trade transformers
- add integration tests for websocket subscription message
- update docs implementation status

## Testing
- `cargo test -p jackbot-data --quiet` *(fails: could not download crates)*