### PR TITLE
Add volatility-adjusted position sizing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "jackbot-macro",
     "jackbot-instrument",
     "jackbot-risk",
-    "jackbot-snapshot"
+    "jackbot-snapshot",
     "jackbot-strategy",
 ]
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -829,8 +829,8 @@ Exchanges currently implementing the `Canonicalizer` trait:
 
  - [x] Position and Exposure Tracking (multi-exchange, spot/futures)
  - [x] Drawdown and Loss Limit Controls
- - [x] Correlation-Based Exposure Management
-- [ ] Volatility-Adjusted Position Sizing
+- [x] Correlation-Based Exposure Management
+- [x] Volatility-Adjusted Position Sizing
 - [ ] Automated Risk Mitigation Actions
 - [ ] Real-time Risk Monitoring and Dashboards
  - [x] Alerting and Notification System

--- a/jackbot-risk/README.md
+++ b/jackbot-risk/README.md
@@ -16,3 +16,12 @@ tracker.check_limit(InstrumentIndex(0), dec!(20), &alerts);
 assert!(!alerts.alerts.lock().unwrap().is_empty());
 ```
 
+```rust
+use jackbot_risk::volatility::VolatilityScaler;
+use rust_decimal_macros::dec;
+
+let scaler = VolatilityScaler::new(dec!(0.02), dec!(0.5), dec!(2));
+let size = scaler.adjust_position(dec!(10), dec!(0.04));
+assert_eq!(size, dec!(5));
+```
+

--- a/jackbot-risk/src/lib.rs
+++ b/jackbot-risk/src/lib.rs
@@ -2,4 +2,5 @@ pub mod alert;
 pub mod exposure;
 pub mod drawdown;
 pub mod correlation;
+pub mod volatility;
 

--- a/jackbot-risk/src/volatility.rs
+++ b/jackbot-risk/src/volatility.rs
@@ -1,0 +1,62 @@
+use derive_more::Constructor;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// Utility for scaling position sizes and risk limits based on volatility.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize, Constructor)]
+pub struct VolatilityScaler {
+    /// Baseline volatility used when the scale factor is 1.0.
+    pub base_volatility: Decimal,
+    /// Minimum allowed scaling factor.
+    pub min_scale: Decimal,
+    /// Maximum allowed scaling factor.
+    pub max_scale: Decimal,
+}
+
+impl VolatilityScaler {
+    /// Calculate a scaling factor for the provided `volatility`.
+    /// Values are clamped between `min_scale` and `max_scale`.
+    pub fn scale(&self, volatility: Decimal) -> Decimal {
+        if volatility <= Decimal::ZERO {
+            return self.max_scale;
+        }
+        let mut factor = self.base_volatility / volatility;
+        if factor < self.min_scale {
+            factor = self.min_scale;
+        } else if factor > self.max_scale {
+            factor = self.max_scale;
+        }
+        factor
+    }
+
+    /// Adjust a base position size using the calculated scaling factor.
+    pub fn adjust_position(&self, base_size: Decimal, volatility: Decimal) -> Decimal {
+        base_size * self.scale(volatility)
+    }
+
+    /// Adjust a risk limit using the calculated scaling factor.
+    pub fn adjust_risk(&self, base_limit: Decimal, volatility: Decimal) -> Decimal {
+        base_limit * self.scale(volatility)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_scale_bounds() {
+        let scaler = VolatilityScaler::new(dec!(0.02), dec!(0.5), dec!(2));
+        assert_eq!(scaler.scale(dec!(0.04)), dec!(0.5));
+        assert_eq!(scaler.scale(dec!(0.01)), dec!(2));
+        assert_eq!(scaler.scale(dec!(0)), dec!(2));
+    }
+
+    #[test]
+    fn test_adjust_position() {
+        let scaler = VolatilityScaler::new(dec!(0.02), dec!(0.5), dec!(2));
+        let adj = scaler.adjust_position(dec!(10), dec!(0.04));
+        assert_eq!(adj, dec!(5));
+    }
+}

--- a/jackbot-risk/tests/integration.rs
+++ b/jackbot-risk/tests/integration.rs
@@ -3,6 +3,7 @@ use jackbot_risk::{
     exposure::ExposureTracker,
     drawdown::DrawdownTracker,
     correlation::CorrelationMatrix,
+    volatility::VolatilityScaler,
 };
 use jackbot_instrument::instrument::InstrumentIndex;
 use rust_decimal_macros::dec;
@@ -33,4 +34,11 @@ fn correlation_alert_triggered() {
     let alerts = VecAlertHook::default();
     corr.check_limit(InstrumentIndex(0), InstrumentIndex(1), dec!(50), &alerts);
     assert!(matches!(alerts.alerts.lock().pop().unwrap(), RiskViolation::CorrelationLimit { .. }));
+}
+
+#[test]
+fn volatility_scaler_adjusts_position() {
+    let scaler = VolatilityScaler::new(dec!(0.02), dec!(0.5), dec!(2));
+    let adjusted = scaler.adjust_position(dec!(10), dec!(0.04));
+    assert_eq!(adjusted, dec!(5));
 }


### PR DESCRIPTION
## Summary
- implement `VolatilityScaler` utility
- expose new module via `jackbot-risk` crate
- test volatility scaling logic
- document new risk module in README
- mark volatility-adjusted position sizing complete in status docs

## Testing
- `cargo test --workspace` *(fails: could not download crates)*