### PR TITLE
Add Bybit trade WebSocket listeners

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "jackbot-macro",
     "jackbot-instrument",
     "jackbot-risk",
-    "jackbot-snapshot"
+    "jackbot-snapshot",
     "jackbot-strategy",
 ]
 

--- a/jackbot-data/src/exchange/bybit/futures/trade.rs
+++ b/jackbot-data/src/exchange/bybit/futures/trade.rs
@@ -1,3 +1,91 @@
-//! Trade event types for Bybit Futures.
+//! Public trade stream types for Bybit Futures.
+//!
+//! Provides a [`StatelessTransformer`](crate::transformer::stateless::StatelessTransformer)
+//! implementation for converting raw Bybit Futures WebSocket trade messages into
+//! normalised [`MarketEvent`](crate::event::MarketEvent)s.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::BybitPerpetualsUsd;
+
+pub use super::super::{message::BybitMessage, trade::BybitTrade};
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Bybit Futures WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type BybitFuturesTradesTransformer<InstrumentKey> =
+    StatelessTransformer<BybitPerpetualsUsd, InstrumentKey, PublicTrades, BybitMessage>;
+
+/// Type alias for a Bybit Futures trades WebSocket stream.
+pub type BybitFuturesTradesStream<InstrumentKey> =
+    ExchangeWsStream<BybitFuturesTradesTransformer<InstrumentKey>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        event::MarketEvent,
+        subscription::Map,
+        transformer::ExchangeTransformer,
+    };
+    use fnv::FnvHashMap;
+    use jackbot_instrument::Side;
+    use jackbot_integration::subscription::SubscriptionId;
+    use tokio::sync::mpsc;
+
+    fn example_trade_json() -> &'static str {
+        r#"{
+            "topic": "publicTrade.BTCUSDT",
+            "type": "snapshot",
+            "ts": 1672304486868,
+            "data": [{
+                "T": 1672304486865,
+                "s": "BTCUSDT",
+                "S": "Sell",
+                "v": "0.001",
+                "p": "16578.50",
+                "L": "PlusTick",
+                "i": "20f43950-d8dd-5b31-9112-a178eb6023af",
+                "BT": false
+            }]
+        }"#
+    }
+
+    #[tokio::test]
+    async fn test_transformer_success() {
+        let sub_id = SubscriptionId::from("publicTrade|BTCUSDT");
+        let mut map = FnvHashMap::default();
+        map.insert(sub_id.clone(), "BTCUSDT".to_string());
+        let map = Map(map);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut transformer =
+            BybitFuturesTradesTransformer::init(map, &[], tx).await.unwrap();
+
+        let msg: BybitMessage = serde_json::from_str(example_trade_json()).unwrap();
+        let events = transformer.transform(msg);
+
+        assert_eq!(events.len(), 1);
+        let MarketEvent { kind, .. } = events.into_iter().next().unwrap().unwrap();
+        assert_eq!(kind.price, 16578.50);
+        assert_eq!(kind.amount, 0.001);
+        assert_eq!(kind.side, Side::Sell);
+    }
+
+    #[tokio::test]
+    async fn test_transformer_unidentifiable() {
+        let map = Map(FnvHashMap::<SubscriptionId, String>::default());
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut transformer =
+            BybitFuturesTradesTransformer::init(map, &[], tx).await.unwrap();
+
+        let msg: BybitMessage = serde_json::from_str(example_trade_json()).unwrap();
+        let events = transformer.transform(msg);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_err());
+    }
+}

--- a/jackbot-data/src/exchange/bybit/spot/trade.rs
+++ b/jackbot-data/src/exchange/bybit/spot/trade.rs
@@ -1,3 +1,91 @@
-//! Trade event types for Bybit Spot.
+//! Public trade stream types for Bybit Spot.
+//!
+//! Provides a [`StatelessTransformer`](crate::transformer::stateless::StatelessTransformer)
+//! implementation for converting raw Bybit WebSocket trade messages into
+//! normalised [`MarketEvent`](crate::event::MarketEvent)s.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::BybitSpot;
+
+pub use super::super::{message::BybitMessage, trade::BybitTrade};
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Bybit Spot WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type BybitSpotTradesTransformer<InstrumentKey> =
+    StatelessTransformer<BybitSpot, InstrumentKey, PublicTrades, BybitMessage>;
+
+/// Type alias for a Bybit Spot trades WebSocket stream.
+pub type BybitSpotTradesStream<InstrumentKey> =
+    ExchangeWsStream<BybitSpotTradesTransformer<InstrumentKey>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        event::MarketEvent,
+        subscription::Map,
+        transformer::ExchangeTransformer,
+    };
+    use fnv::FnvHashMap;
+    use jackbot_instrument::Side;
+    use jackbot_integration::subscription::SubscriptionId;
+    use tokio::sync::mpsc;
+
+    fn example_trade_json() -> &'static str {
+        r#"{
+            "topic": "publicTrade.BTCUSDT",
+            "type": "snapshot",
+            "ts": 1672304486868,
+            "data": [{
+                "T": 1672304486865,
+                "s": "BTCUSDT",
+                "S": "Buy",
+                "v": "0.001",
+                "p": "16578.50",
+                "L": "PlusTick",
+                "i": "20f43950-d8dd-5b31-9112-a178eb6023af",
+                "BT": false
+            }]
+        }"#
+    }
+
+    #[tokio::test]
+    async fn test_transformer_success() {
+        let sub_id = SubscriptionId::from("publicTrade|BTCUSDT");
+        let mut map = FnvHashMap::default();
+        map.insert(sub_id.clone(), "BTCUSDT".to_string());
+        let map = Map(map);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut transformer =
+            BybitSpotTradesTransformer::init(map, &[], tx).await.unwrap();
+
+        let msg: BybitMessage = serde_json::from_str(example_trade_json()).unwrap();
+        let events = transformer.transform(msg);
+
+        assert_eq!(events.len(), 1);
+        let MarketEvent { kind, .. } = events.into_iter().next().unwrap().unwrap();
+        assert_eq!(kind.price, 16578.50);
+        assert_eq!(kind.amount, 0.001);
+        assert_eq!(kind.side, Side::Buy);
+    }
+
+    #[tokio::test]
+    async fn test_transformer_unidentifiable() {
+        let map = Map(FnvHashMap::<SubscriptionId, String>::default());
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut transformer =
+            BybitSpotTradesTransformer::init(map, &[], tx).await.unwrap();
+
+        let msg: BybitMessage = serde_json::from_str(example_trade_json()).unwrap();
+        let events = transformer.transform(msg);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- add Bybit Spot/Futures trade transformer modules
- provide tests for Bybit Spot and Futures transformers
- fix workspace Cargo.toml formatting

## Testing
- `cargo test --workspace --quiet` *(fails: could not download crates)*