### PR TITLE
Implement Kucoin L2 Order Books

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "jackbot-macro",
     "jackbot-instrument",
     "jackbot-risk",
-    "jackbot-snapshot"
+    "jackbot-snapshot",
     "jackbot-strategy",
 ]
 

--- a/jackbot-data/src/exchange/kucoin/channel.rs
+++ b/jackbot-data/src/exchange/kucoin/channel.rs
@@ -1,16 +1,28 @@
 //! Channel definitions for Kucoin exchange.
 
-#[derive(Debug, Clone)]
-pub struct KucoinChannel;
+use serde::{Deserialize, Serialize};
+
+/// Channel identifier for Kucoin WebSocket subscriptions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct KucoinChannel(pub &'static str);
+
+impl AsRef<str> for KucoinChannel {
+    fn as_ref(&self) -> &str {
+        self.0
+    }
+}
 
 impl KucoinChannel {
-    pub fn as_str(&self) -> &str {
-        // TODO: implement channel string
-        ""
-    }
+    /// Kucoin real-time Level 2 order book channel name.
+    pub const ORDER_BOOK_L2: Self = Self("level2");
 }
 
 #[cfg(test)]
 mod tests {
-    // TODO: add tests
+    use super::*;
+
+    #[test]
+    fn test_channel_consts() {
+        assert_eq!(KucoinChannel::ORDER_BOOK_L2.as_ref(), "level2");
+    }
 }

--- a/jackbot-data/src/exchange/kucoin/futures/l2.rs
+++ b/jackbot-data/src/exchange/kucoin/futures/l2.rs
@@ -1,5 +1,4 @@
-// Kucoin Order Book L2 stub
-
+//! Level 2 order book types for Kucoin futures.
 use crate::{
     Identifier,
     books::{Canonicalizer, Level, OrderBook},
@@ -14,9 +13,8 @@ use jackbot_integration::subscription::SubscriptionId;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
-/// Kucoin real-time OrderBook Level2 message.
 #[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
-pub struct KucoinOrderBookL2 {
+pub struct KucoinFuturesOrderBookL2 {
     #[serde(alias = "symbol", deserialize_with = "de_ob_l2_subscription_id")]
     pub subscription_id: SubscriptionId,
     #[serde(default = "Utc::now")]
@@ -27,13 +25,13 @@ pub struct KucoinOrderBookL2 {
     pub asks: Vec<(Decimal, Decimal)>,
 }
 
-impl Identifier<Option<SubscriptionId>> for KucoinOrderBookL2 {
+impl Identifier<Option<SubscriptionId>> for KucoinFuturesOrderBookL2 {
     fn id(&self) -> Option<SubscriptionId> {
         Some(self.subscription_id.clone())
     }
 }
 
-impl Canonicalizer for KucoinOrderBookL2 {
+impl Canonicalizer for KucoinFuturesOrderBookL2 {
     fn canonicalize(&self, timestamp: DateTime<Utc>) -> OrderBook {
         let bids = self.bids.iter().map(|(p, a)| Level::new(*p, *a));
         let asks = self.asks.iter().map(|(p, a)| Level::new(*p, *a));
@@ -41,7 +39,7 @@ impl Canonicalizer for KucoinOrderBookL2 {
     }
 }
 
-impl KucoinOrderBookL2 {
+impl KucoinFuturesOrderBookL2 {
     /// Persist this order book snapshot to the provided [`RedisStore`].
     pub fn store_snapshot<Store: RedisStore>(&self, store: &Store) {
         let snapshot = self.canonicalize(self.time);
@@ -55,14 +53,11 @@ impl KucoinOrderBookL2 {
     }
 }
 
-impl<InstrumentKey> From<(ExchangeId, InstrumentKey, KucoinOrderBookL2)>
+impl<InstrumentKey> From<(ExchangeId, InstrumentKey, KucoinFuturesOrderBookL2)>
     for MarketIter<InstrumentKey, OrderBookEvent>
 {
-    fn from(
-        (exchange_id, instrument, book): (ExchangeId, InstrumentKey, KucoinOrderBookL2),
-    ) -> Self {
+    fn from((exchange_id, instrument, book): (ExchangeId, InstrumentKey, KucoinFuturesOrderBookL2)) -> Self {
         let order_book = book.canonicalize(book.time);
-
         Self(vec![Ok(MarketEvent {
             time_exchange: book.time,
             time_received: Utc::now(),
@@ -73,7 +68,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, KucoinOrderBookL2)>
     }
 }
 
-/// Deserialize a KucoinOrderBookL2 "symbol" as the associated SubscriptionId.
+/// Deserialize a `KucoinFuturesOrderBookL2` "symbol" as the associated `SubscriptionId`.
 pub fn de_ob_l2_subscription_id<'de, D>(deserializer: D) -> Result<SubscriptionId, D::Error>
 where
     D: serde::de::Deserializer<'de>,
@@ -89,9 +84,9 @@ mod tests {
     use rust_decimal_macros::dec;
 
     #[test]
-    fn test_kucoin_order_book_l2() {
+    fn test_kucoin_futures_order_book_l2() {
         let input = r#"{\"symbol\":\"BTC-USDT\",\"bids\":[[\"30000.0\",\"1.0\"]],\"asks\":[[\"30010.0\",\"2.0\"]]}"#;
-        let book: KucoinOrderBookL2 = serde_json::from_str(input).unwrap();
+        let book: KucoinFuturesOrderBookL2 = serde_json::from_str(input).unwrap();
         assert_eq!(book.bids[0], (dec!(30000.0), dec!(1.0)));
         assert_eq!(book.asks[0], (dec!(30010.0), dec!(2.0)));
     }
@@ -99,7 +94,7 @@ mod tests {
     #[test]
     fn test_store_methods() {
         let store = InMemoryStore::new();
-        let book = KucoinOrderBookL2 {
+        let book = KucoinFuturesOrderBookL2 {
             subscription_id: "BTC-USDT".into(),
             time: Utc::now(),
             bids: vec![(dec!(30000.0), dec!(1.0))],
@@ -108,7 +103,7 @@ mod tests {
         book.store_snapshot(&store);
         assert!(store.get_snapshot(ExchangeId::Kucoin, "BTC-USDT").is_some());
 
-        let delta_book = KucoinOrderBookL2 { time: Utc::now(), ..book };
+        let delta_book = KucoinFuturesOrderBookL2 { time: Utc::now(), ..book };
         delta_book.store_delta(&store);
         assert_eq!(store.delta_len(ExchangeId::Kucoin, "BTC-USDT"), 1);
     }

--- a/jackbot-data/src/exchange/kucoin/futures/mod.rs
+++ b/jackbot-data/src/exchange/kucoin/futures/mod.rs
@@ -1,5 +1,6 @@
 //! Futures market modules for Kucoin.
-//
-// Not yet implemented. This is a stub for future expansion.
+//!
+//! Currently provides Level 2 order book message types and trades.
 
+pub mod l2;
 pub mod trade;

--- a/jackbot-data/src/exchange/kucoin/mod.rs
+++ b/jackbot-data/src/exchange/kucoin/mod.rs
@@ -22,7 +22,7 @@ use url::Url;
 
 pub mod book;
 pub mod channel;
-/// Futures market modules for Kucoin (stub; not yet implemented).
+/// Futures market modules for Kucoin.
 pub mod futures;
 pub mod liquidation;
 pub mod market;


### PR DESCRIPTION
## Summary
- add channel constants for Kucoin
- implement Redis store helpers and Canonicalizer for Kucoin spot L2 order book
- implement Kucoin futures L2 order book module
- expose futures L2 module
- fix workspace Cargo.toml

## Testing
- `cargo check -p jackbot-data --quiet` *(fails: Could not connect to server)*