### PR TITLE
Add Hyperliquid L2 tests and workspace fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "jackbot-macro",
     "jackbot-instrument",
     "jackbot-risk",
-    "jackbot-snapshot"
+    "jackbot-snapshot",
     "jackbot-strategy",
 ]
 

--- a/jackbot-data/src/exchange/hyperliquid/futures/l2.rs
+++ b/jackbot-data/src/exchange/hyperliquid/futures/l2.rs
@@ -67,6 +67,7 @@ where
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;
+    use crate::books::Level;
 
     #[test]
     fn test_hyperliquid_futures_order_book_l2() {
@@ -74,5 +75,8 @@ mod tests {
         let book: HyperliquidFuturesOrderBookL2 = serde_json::from_str(input).unwrap();
         assert_eq!(book.bids[0], (dec!(30000.0), dec!(1.0)));
         assert_eq!(book.asks[0], (dec!(30010.0), dec!(2.0)));
+        let canonical = book.canonicalize(book.time);
+        assert_eq!(canonical.bids().levels()[0], Level::new(dec!(30000.0), dec!(1.0)));
+        assert_eq!(canonical.asks().levels()[0], Level::new(dec!(30010.0), dec!(2.0)));
     }
 }

--- a/jackbot-data/src/exchange/hyperliquid/spot/l2.rs
+++ b/jackbot-data/src/exchange/hyperliquid/spot/l2.rs
@@ -71,6 +71,7 @@ where
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;
+    use crate::books::Level;
 
     #[test]
     fn test_hyperliquid_order_book_l2() {
@@ -78,5 +79,8 @@ mod tests {
         let book: HyperliquidOrderBookL2 = serde_json::from_str(input).unwrap();
         assert_eq!(book.bids[0], (dec!(30000.0), dec!(1.0)));
         assert_eq!(book.asks[0], (dec!(30010.0), dec!(2.0)));
+        let canonical = book.canonicalize(book.time);
+        assert_eq!(canonical.bids().levels()[0], Level::new(dec!(30000.0), dec!(1.0)));
+        assert_eq!(canonical.asks().levels()[0], Level::new(dec!(30010.0), dec!(2.0)));
     }
 }


### PR DESCRIPTION
## Summary
- fix workspace members list
- expand Hyperliquid spot and futures L2 order book tests to check canonicalization

## Testing
- `cargo check --manifest-path jackbot-data/Cargo.toml --offline` *(fails: no matching package named `chrono` found)*