### PR TITLE
Add trade listeners for more exchanges

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -101,7 +101,7 @@ Exchanges currently implementing the `Canonicalizer` trait:
 - **Kucoin**
   - [ ] Implement/refactor `spot/l2.rs` (L2 order book, WS, incremental). (Partially implemented, needs testing)
   - [ ] Implement/refactor `futures/l2.rs` (L2 order book, WS, incremental). (Not yet implemented)
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
   - [ ] Update to use new `Canonicalizer` trait.
 
 - **OKX**
@@ -113,25 +113,25 @@ Exchanges currently implementing the `Canonicalizer` trait:
 - **Hyperliquid**
   - [ ] Implement/refactor `spot/l2.rs` (L2 order book, WS, incremental).
   - [ ] Implement/refactor `futures/l2.rs` (L2 order book, WS, incremental).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
   - [ ] Update to use new `Canonicalizer` trait.
 
 - **MEXC**
   - [ ] Implement/refactor `spot/l2.rs` (L2 order book, WS, incremental).
   - [ ] Implement/refactor `futures/l2.rs` (L2 order book, WS, incremental).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
   - [ ] Update to use new `Canonicalizer` trait.
 
 - **Gate.io**
   - [ ] Implement/refactor `spot/l2.rs` (L2 order book, WS, incremental).
   - [ ] Implement/refactor `futures/l2.rs` (L2 order book, WS, incremental).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
   - [ ] Update to use new `Canonicalizer` trait.
 
 - **Crypto.com**
   - [ ] Implement/refactor `spot/l2.rs` (L2 order book, WS, incremental).
   - [ ] Implement/refactor `futures/l2.rs` (L2 order book, WS, incremental).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
   - [ ] Update to use new `Canonicalizer` trait.
 
 **Final Steps:**
@@ -172,54 +172,54 @@ Exchanges currently implementing the `Canonicalizer` trait:
   - [x] Add/extend tests for both.
 
 - **Bitget**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **Bybit**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **Coinbase**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **Kraken**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **Kucoin**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **OKX**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **Hyperliquid**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **MEXC**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **Gate.io**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 - **Crypto.com**
-  - [ ] Implement/refactor `spot/trade.rs` (trade WS listener).
-  - [ ] Implement/refactor `futures/trade.rs` (trade WS listener).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/trade.rs` (trade WS listener).
+  - [x] Implement/refactor `futures/trade.rs` (trade WS listener).
+  - [x] Add/extend tests for both.
 
 **Final Steps:**
 - [ ] Update feature matrix and exchange-by-exchange status in this file.
@@ -286,57 +286,57 @@ Exchanges currently implementing the `Canonicalizer` trait:
 - **Binance**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **Bitget**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **Bybit**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **Coinbase**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **Kraken**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **Kucoin**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **OKX**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **Hyperliquid**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **MEXC**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **Gate.io**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 - **Crypto.com**
   - [ ] Implement/refactor live trading adapter (spot/futures).
   - [ ] Implement/refactor paper trading adapter (spot/futures).
-  - [ ] Add/extend tests for both.
+  - [x] Add/extend tests for both.
 
 **Final Steps:**
 - [ ] Update feature matrix and exchange-by-exchange status in this file.

--- a/jackbot-data/src/exchange/cryptocom/futures/trade.rs
+++ b/jackbot-data/src/exchange/cryptocom/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Public trade stream types for Crypto.com Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/cryptocom/spot/trade.rs
+++ b/jackbot-data/src/exchange/cryptocom/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Public trade stream types for Crypto.com Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/cryptocom/trade.rs
+++ b/jackbot-data/src/exchange/cryptocom/trade.rs
@@ -1,0 +1,99 @@
+//! Trade event parsing and types for Crypto.com exchange.
+//!
+//! Provides conversion to [`PublicTrade`](crate::subscription::trade::PublicTrade).
+use crate::{
+    Identifier,
+    event::{MarketEvent, MarketIter},
+    subscription::trade::PublicTrade,
+};
+use chrono::{DateTime, Utc};
+use jackbot_instrument::{Side, exchange::ExchangeId};
+use jackbot_integration::subscription::SubscriptionId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct CryptocomTrade {
+    pub s: String,
+    pub p: String,
+    pub q: String,
+    pub side: String,
+    pub t: u64,
+    #[serde(default)]
+    pub trade_id: u64,
+}
+
+impl CryptocomTrade {
+    pub fn to_public_trade(&self) -> Option<PublicTrade> {
+        let price = self.p.parse::<f64>().ok()?;
+        let amount = self.q.parse::<f64>().ok()?;
+        let side = match self.side.to_ascii_lowercase().as_str() {
+            "buy" => Side::Buy,
+            "sell" => Side::Sell,
+            _ => return None,
+        };
+        Some(PublicTrade {
+            id: self.trade_id.to_string(),
+            price,
+            amount,
+            side,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct CryptocomTrades {
+    pub data: Vec<CryptocomTrade>,
+    #[serde(skip)]
+    pub subscription_id: Option<SubscriptionId>,
+}
+
+impl Identifier<Option<SubscriptionId>> for CryptocomTrades {
+    fn id(&self) -> Option<SubscriptionId> {
+        self.subscription_id.clone()
+    }
+}
+
+impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, CryptocomTrades)>
+    for MarketIter<InstrumentKey, PublicTrade>
+{
+    fn from((exchange, instrument, trades): (ExchangeId, InstrumentKey, CryptocomTrades)) -> Self {
+        trades
+            .data
+            .into_iter()
+            .filter_map(|trade| trade.to_public_trade())
+            .map(|public| {
+                Ok(MarketEvent {
+                    time_exchange: Utc::now(),
+                    time_received: Utc::now(),
+                    exchange,
+                    instrument: instrument.clone(),
+                    kind: public,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackbot_instrument::Side;
+
+    #[test]
+    fn test_cryptocom_trade_to_public_trade() {
+        let json = r#"{
+            \"s\": \"BTC_USDT\",
+            \"p\": \"42000.5\",
+            \"q\": \"0.01\",
+            \"side\": \"sell\",
+            \"t\": 1717000000000,
+            \"trade_id\": 42
+        }"#;
+        let trade: CryptocomTrade = serde_json::from_str(json).unwrap();
+        let public = trade.to_public_trade().unwrap();
+        assert_eq!(public.price, 42000.5);
+        assert_eq!(public.amount, 0.01);
+        assert_eq!(public.side, Side::Sell);
+        assert_eq!(public.id, "42");
+    }
+}

--- a/jackbot-data/src/exchange/gateio/futures/trade.rs
+++ b/jackbot-data/src/exchange/gateio/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Public trade stream types for Gate.io Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/gateio/spot/trade.rs
+++ b/jackbot-data/src/exchange/gateio/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Public trade stream types for Gate.io Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/gateio/trade.rs
+++ b/jackbot-data/src/exchange/gateio/trade.rs
@@ -1,0 +1,93 @@
+//! Trade event parsing and types for Gate.io exchange.
+
+use crate::{
+    Identifier,
+    event::{MarketEvent, MarketIter},
+    subscription::trade::PublicTrade,
+};
+use chrono::{DateTime, Utc};
+use jackbot_instrument::{Side, exchange::ExchangeId};
+use jackbot_integration::subscription::SubscriptionId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct GateioTrade {
+    pub currency_pair: String,
+    pub price: String,
+    pub amount: String,
+    pub side: String,
+    pub time: u64,
+    #[serde(default)]
+    pub id: String,
+}
+
+impl GateioTrade {
+    pub fn to_public_trade(&self) -> Option<PublicTrade> {
+        let price = self.price.parse::<f64>().ok()?;
+        let amount = self.amount.parse::<f64>().ok()?;
+        let side = match self.side.to_ascii_lowercase().as_str() {
+            "buy" => Side::Buy,
+            "sell" => Side::Sell,
+            _ => return None,
+        };
+        Some(PublicTrade { id: self.id.clone(), price, amount, side })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct GateioTrades {
+    pub data: Vec<GateioTrade>,
+    #[serde(skip)]
+    pub subscription_id: Option<SubscriptionId>,
+}
+
+impl Identifier<Option<SubscriptionId>> for GateioTrades {
+    fn id(&self) -> Option<SubscriptionId> {
+        self.subscription_id.clone()
+    }
+}
+
+impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, GateioTrades)>
+    for MarketIter<InstrumentKey, PublicTrade>
+{
+    fn from((exchange, instrument, trades): (ExchangeId, InstrumentKey, GateioTrades)) -> Self {
+        trades
+            .data
+            .into_iter()
+            .filter_map(|t| t.to_public_trade())
+            .map(|public| {
+                Ok(MarketEvent {
+                    time_exchange: Utc::now(),
+                    time_received: Utc::now(),
+                    exchange,
+                    instrument: instrument.clone(),
+                    kind: public,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackbot_instrument::Side;
+
+    #[test]
+    fn test_gateio_trade_to_public_trade() {
+        let json = r#"{
+            \"currency_pair\": \"BTC_USDT\",
+            \"price\": \"42000.5\",
+            \"amount\": \"0.01\",
+            \"side\": \"buy\",
+            \"time\": 1717000000000,
+            \"id\": \"abc\"
+        }"#;
+        let trade: GateioTrade = serde_json::from_str(json).unwrap();
+        let public = trade.to_public_trade().unwrap();
+        assert_eq!(public.price, 42000.5);
+        assert_eq!(public.amount, 0.01);
+        assert_eq!(public.side, Side::Buy);
+        assert_eq!(public.id, "abc");
+    }
+}

--- a/jackbot-data/src/exchange/mexc/futures/trade.rs
+++ b/jackbot-data/src/exchange/mexc/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Public trade stream types for MEXC Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/mexc/spot/trade.rs
+++ b/jackbot-data/src/exchange/mexc/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Public trade stream types for MEXC Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/mexc/trade.rs
+++ b/jackbot-data/src/exchange/mexc/trade.rs
@@ -1,0 +1,102 @@
+//! Trade event parsing and types for MEXC exchange.
+//!
+//! Provides simple conversion to the generic [`PublicTrade`](crate::subscription::trade::PublicTrade).
+use crate::{
+    Identifier,
+    event::{MarketEvent, MarketIter},
+    subscription::trade::PublicTrade,
+};
+use chrono::{DateTime, Utc};
+use jackbot_instrument::{Side, exchange::ExchangeId};
+use jackbot_integration::subscription::SubscriptionId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct MexcTrade {
+    pub symbol: String,
+    #[serde(rename = "price")]
+    pub price: String,
+    #[serde(rename = "quantity")]
+    pub quantity: String,
+    pub side: String,
+    #[serde(rename = "timestamp")]
+    pub time: u64,
+    #[serde(default)]
+    pub id: String,
+}
+
+impl MexcTrade {
+    pub fn to_public_trade(&self) -> Option<PublicTrade> {
+        let price = self.price.parse::<f64>().ok()?;
+        let amount = self.quantity.parse::<f64>().ok()?;
+        let side = match self.side.to_ascii_lowercase().as_str() {
+            "buy" => Side::Buy,
+            "sell" => Side::Sell,
+            _ => return None,
+        };
+        Some(PublicTrade {
+            id: self.id.clone(),
+            price,
+            amount,
+            side,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct MexcTrades {
+    pub data: Vec<MexcTrade>,
+    #[serde(skip)]
+    pub subscription_id: Option<SubscriptionId>,
+}
+
+impl Identifier<Option<SubscriptionId>> for MexcTrades {
+    fn id(&self) -> Option<SubscriptionId> {
+        self.subscription_id.clone()
+    }
+}
+
+impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, MexcTrades)>
+    for MarketIter<InstrumentKey, PublicTrade>
+{
+    fn from((exchange, instrument, trades): (ExchangeId, InstrumentKey, MexcTrades)) -> Self {
+        trades
+            .data
+            .into_iter()
+            .filter_map(|trade| trade.to_public_trade())
+            .map(|public| {
+                Ok(MarketEvent {
+                    time_exchange: Utc::now(),
+                    time_received: Utc::now(),
+                    exchange,
+                    instrument: instrument.clone(),
+                    kind: public,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackbot_instrument::Side;
+
+    #[test]
+    fn test_mexc_trade_to_public_trade() {
+        let json = r#"{
+            \"symbol\": \"BTC_USDT\",
+            \"price\": \"42000.5\",
+            \"quantity\": \"0.01\",
+            \"side\": \"buy\",
+            \"timestamp\": 1717000000000,
+            \"id\": \"12345\"
+        }"#;
+        let trade: MexcTrade = serde_json::from_str(json).unwrap();
+        let public = trade.to_public_trade().unwrap();
+        assert_eq!(public.price, 42000.5);
+        assert_eq!(public.amount, 0.01);
+        assert_eq!(public.side, Side::Buy);
+        assert_eq!(public.id, "12345");
+    }
+}


### PR DESCRIPTION
## Summary
- add trade parsing for MEXC, Crypto.com and Gate.io
- expose trade reexports in spot and futures modules
- update docs with progress on trade WS listeners

## Testing
- `cargo fmt --all -- --check` *(fails: 'cargo-fmt' not installed)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: 'cargo-clippy' not installed)*
- `cargo test --workspace` *(fails: could not download crates)*