### PR TITLE
Add Gate.io L2 order book modules

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -123,9 +123,9 @@ Exchanges currently implementing the `Canonicalizer` trait:
   - [ ] Update to use new `Canonicalizer` trait.
 
 - **Gate.io**
-  - [ ] Implement/refactor `spot/l2.rs` (L2 order book, WS, incremental).
-  - [ ] Implement/refactor `futures/l2.rs` (L2 order book, WS, incremental).
-  - [ ] Add/extend tests for both.
+  - [x] Implement/refactor `spot/l2.rs` (L2 order book, WS, incremental). (Canonicalization implemented)
+  - [x] Implement/refactor `futures/l2.rs` (L2 order book, WS, incremental). (Canonicalization implemented)
+  - [x] Add/extend tests for both.
   - [ ] Update to use new `Canonicalizer` trait.
 
 - **Crypto.com**
@@ -141,8 +141,8 @@ Exchanges currently implementing the `Canonicalizer` trait:
 
 **Implementation Summary:**
 - Complete L2 Order Book implementations for: Binance (Spot & Futures), Bybit (Spot & Futures), Coinbase (Spot), Kraken (Spot & Futures), OKX (Spot & Futures), Bitget (Spot & Futures)
-- Partially implemented for: Kucoin (Spot), Crypto.com (Spot & Futures), MEXC (Spot & Futures), Hyperliquid (Spot & Futures)
-- Not yet implemented for: Kucoin (Futures), Gate.io
+- Partially implemented for: Kucoin (Spot), Crypto.com (Spot & Futures), MEXC (Spot & Futures), Hyperliquid (Spot & Futures), Gate.io (Spot & Futures)
+- Not yet implemented for: Kucoin (Futures)
 - Canonicalizer implementations for: Bybit (Spot & Futures), Kraken (Spot & Futures), Binance (Spot & Futures), OKX (Spot & Futures), Coinbase (Spot), Bitget (Spot & Futures), MEXC (Spot & Futures), Crypto.com (Spot & Futures), Hyperliquid (Spot & Futures)
 
 **Next Steps:**

--- a/jackbot-data/src/exchange/gate/futures/l2.rs
+++ b/jackbot-data/src/exchange/gate/futures/l2.rs
@@ -1,0 +1,101 @@
+//! Level 2 order book types for Gate.io futures.
+use crate::{
+    Identifier,
+    books::{Canonicalizer, Level, OrderBook},
+    event::{MarketEvent, MarketIter},
+    redis_store::RedisStore,
+    subscription::book::{OrderBookEvent, OrderBooksL2},
+};
+use chrono::{DateTime, Utc};
+use jackbot_instrument::exchange::ExchangeId;
+use jackbot_integration::subscription::SubscriptionId;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// Gate.io futures OrderBook Level2 message.
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct GateFuturesOrderBookL2 {
+    #[serde(alias = "contract")]
+    pub subscription_id: SubscriptionId,
+    #[serde(default = "Utc::now")]
+    pub time: DateTime<Utc>,
+    #[serde(alias = "bids")]
+    pub bids: Vec<(Decimal, Decimal)>,
+    #[serde(alias = "asks")]
+    pub asks: Vec<(Decimal, Decimal)>,
+}
+
+impl Identifier<Option<SubscriptionId>> for GateFuturesOrderBookL2 {
+    fn id(&self) -> Option<SubscriptionId> {
+        Some(self.subscription_id.clone())
+    }
+}
+
+impl Canonicalizer for GateFuturesOrderBookL2 {
+    fn canonicalize(&self, timestamp: DateTime<Utc>) -> OrderBook {
+        let bids = self.bids.iter().map(|(p, a)| Level::new(*p, *a));
+        let asks = self.asks.iter().map(|(p, a)| Level::new(*p, *a));
+        OrderBook::new(0, Some(timestamp), bids, asks)
+    }
+}
+
+impl GateFuturesOrderBookL2 {
+    /// Persist this order book snapshot to the provided [`RedisStore`].
+    pub fn store_snapshot<Store: RedisStore>(&self, store: &Store) {
+        let snapshot = self.canonicalize(self.time);
+        store.store_snapshot(ExchangeId::GateIo, self.subscription_id.as_ref(), &snapshot);
+    }
+
+    /// Persist this order book update to the provided [`RedisStore`].
+    pub fn store_delta<Store: RedisStore>(&self, store: &Store) {
+        let delta = OrderBookEvent::Update(self.canonicalize(self.time));
+        store.store_delta(ExchangeId::GateIo, self.subscription_id.as_ref(), &delta);
+    }
+}
+
+impl<InstrumentKey> From<(ExchangeId, InstrumentKey, GateFuturesOrderBookL2)>
+    for MarketIter<InstrumentKey, OrderBookEvent>
+{
+    fn from((exchange_id, instrument, book): (ExchangeId, InstrumentKey, GateFuturesOrderBookL2)) -> Self {
+        let order_book = book.canonicalize(book.time);
+        Self(vec![Ok(MarketEvent {
+            time_exchange: book.time,
+            time_received: Utc::now(),
+            exchange: exchange_id,
+            instrument,
+            kind: OrderBookEvent::Update(order_book),
+        })])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::redis_store::InMemoryStore;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_gate_futures_order_book_l2() {
+        let input = r#"{\"contract\":\"BTC_USDT\",\"bids\":[[\"30000.0\",\"1.0\"]],\"asks\":[[\"30010.0\",\"2.0\"]]}"#;
+        let book: GateFuturesOrderBookL2 = serde_json::from_str(input).unwrap();
+        assert_eq!(book.bids[0], (dec!(30000.0), dec!(1.0)));
+        assert_eq!(book.asks[0], (dec!(30010.0), dec!(2.0)));
+    }
+
+    #[test]
+    fn test_store_methods() {
+        let store = InMemoryStore::new();
+        let book = GateFuturesOrderBookL2 {
+            subscription_id: "BTC_USDT".into(),
+            time: Utc::now(),
+            bids: vec![(dec!(30000.0), dec!(1.0))],
+            asks: vec![(dec!(30010.0), dec!(2.0))],
+        };
+        book.store_snapshot(&store);
+        assert!(store.get_snapshot(ExchangeId::GateIo, "BTC_USDT").is_some());
+
+        let delta_book = GateFuturesOrderBookL2 { time: Utc::now(), ..book };
+        delta_book.store_delta(&store);
+        assert_eq!(store.delta_len(ExchangeId::GateIo, "BTC_USDT"), 1);
+    }
+}

--- a/jackbot-data/src/exchange/gate/futures/mod.rs
+++ b/jackbot-data/src/exchange/gate/futures/mod.rs
@@ -1,0 +1,3 @@
+//! Futures market modules for Gate.io.
+
+pub mod l2;

--- a/jackbot-data/src/exchange/gate/mod.rs
+++ b/jackbot-data/src/exchange/gate/mod.rs
@@ -1,0 +1,6 @@
+//! Gate.io exchange module.
+//!
+//! This module contains spot and futures market submodules for Gate.io.
+
+pub mod spot;
+pub mod futures;

--- a/jackbot-data/src/exchange/gate/spot/l2.rs
+++ b/jackbot-data/src/exchange/gate/spot/l2.rs
@@ -1,0 +1,101 @@
+//! Level 2 order book types for Gate.io spot.
+use crate::{
+    Identifier,
+    books::{Canonicalizer, Level, OrderBook},
+    event::{MarketEvent, MarketIter},
+    redis_store::RedisStore,
+    subscription::book::{OrderBookEvent, OrderBooksL2},
+};
+use chrono::{DateTime, Utc};
+use jackbot_instrument::exchange::ExchangeId;
+use jackbot_integration::subscription::SubscriptionId;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// Gate.io real-time OrderBook Level2 message.
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct GateOrderBookL2 {
+    #[serde(alias = "currency_pair")]
+    pub subscription_id: SubscriptionId,
+    #[serde(default = "Utc::now")]
+    pub time: DateTime<Utc>,
+    #[serde(alias = "bids")]
+    pub bids: Vec<(Decimal, Decimal)>,
+    #[serde(alias = "asks")]
+    pub asks: Vec<(Decimal, Decimal)>,
+}
+
+impl Identifier<Option<SubscriptionId>> for GateOrderBookL2 {
+    fn id(&self) -> Option<SubscriptionId> {
+        Some(self.subscription_id.clone())
+    }
+}
+
+impl Canonicalizer for GateOrderBookL2 {
+    fn canonicalize(&self, timestamp: DateTime<Utc>) -> OrderBook {
+        let bids = self.bids.iter().map(|(p, a)| Level::new(*p, *a));
+        let asks = self.asks.iter().map(|(p, a)| Level::new(*p, *a));
+        OrderBook::new(0, Some(timestamp), bids, asks)
+    }
+}
+
+impl GateOrderBookL2 {
+    /// Persist this order book snapshot to the provided [`RedisStore`].
+    pub fn store_snapshot<Store: RedisStore>(&self, store: &Store) {
+        let snapshot = self.canonicalize(self.time);
+        store.store_snapshot(ExchangeId::GateIo, self.subscription_id.as_ref(), &snapshot);
+    }
+
+    /// Persist this order book update to the provided [`RedisStore`].
+    pub fn store_delta<Store: RedisStore>(&self, store: &Store) {
+        let delta = OrderBookEvent::Update(self.canonicalize(self.time));
+        store.store_delta(ExchangeId::GateIo, self.subscription_id.as_ref(), &delta);
+    }
+}
+
+impl<InstrumentKey> From<(ExchangeId, InstrumentKey, GateOrderBookL2)>
+    for MarketIter<InstrumentKey, OrderBookEvent>
+{
+    fn from((exchange_id, instrument, book): (ExchangeId, InstrumentKey, GateOrderBookL2)) -> Self {
+        let order_book = book.canonicalize(book.time);
+        Self(vec![Ok(MarketEvent {
+            time_exchange: book.time,
+            time_received: Utc::now(),
+            exchange: exchange_id,
+            instrument,
+            kind: OrderBookEvent::Update(order_book),
+        })])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::redis_store::InMemoryStore;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_gate_spot_order_book_l2() {
+        let input = r#"{\"currency_pair\":\"BTC_USDT\",\"bids\":[[\"30000.0\",\"1.0\"]],\"asks\":[[\"30010.0\",\"2.0\"]]}"#;
+        let book: GateOrderBookL2 = serde_json::from_str(input).unwrap();
+        assert_eq!(book.bids[0], (dec!(30000.0), dec!(1.0)));
+        assert_eq!(book.asks[0], (dec!(30010.0), dec!(2.0)));
+    }
+
+    #[test]
+    fn test_store_methods() {
+        let store = InMemoryStore::new();
+        let book = GateOrderBookL2 {
+            subscription_id: "BTC_USDT".into(),
+            time: Utc::now(),
+            bids: vec![(dec!(30000.0), dec!(1.0))],
+            asks: vec![(dec!(30010.0), dec!(2.0))],
+        };
+        book.store_snapshot(&store);
+        assert!(store.get_snapshot(ExchangeId::GateIo, "BTC_USDT").is_some());
+
+        let delta_book = GateOrderBookL2 { time: Utc::now(), ..book };
+        delta_book.store_delta(&store);
+        assert_eq!(store.delta_len(ExchangeId::GateIo, "BTC_USDT"), 1);
+    }
+}

--- a/jackbot-data/src/exchange/gate/spot/mod.rs
+++ b/jackbot-data/src/exchange/gate/spot/mod.rs
@@ -1,0 +1,3 @@
+//! Spot market modules for Gate.io.
+
+pub mod l2;


### PR DESCRIPTION
## Summary
- add Gate.io spot/futures L2 order book structs with tests
- document Gate.io progress in IMPLEMENTATION_STATUS

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt not installed)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy not installed)*
- `cargo test --workspace` *(fails: could not fetch crates)*