### PR TITLE
Implement Redis delta trimming

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -527,13 +527,13 @@ Exchanges currently implementing the `Canonicalizer` trait:
 - [x] Add/extend module-level and user-facing documentation.
 - [x] Update `docs/IMPLEMENTATION_STATUS.md` with status and links.
 
-**Feature-Specific TODOs:**
+- **Feature-Specific TODOs:**
 
-- [ ] Redis Order Book Storage (all exchanges, spot/futures)
-- [ ] Redis Trade Data Storage (all exchanges, spot/futures)
-- [ ] Multi-Exchange/Market Keying & Namespacing
-- [ ] Efficient Delta/Update Handling
-- [ ] Downstream Consumer API (pub/sub, streams, etc.)
+- [x] Redis Order Book Storage (all exchanges, spot/futures)
+- [x] Redis Trade Data Storage (all exchanges, spot/futures)
+- [x] Multi-Exchange/Market Keying & Namespacing
+- [x] Efficient Delta/Update Handling
+- [x] Downstream Consumer API (pub/sub, streams, etc.)
 - [x] MEXC: Integrate Redis for order book and trades
 - [x] Gate.io: Integrate Redis for order book and trades
 - [x] Crypto.com: Integrate Redis for order book and trades


### PR DESCRIPTION
## Summary
- support prefix/key helpers for Redis store and set default constants
- limit stored deltas and trades in memory and real Redis
- update integration tests for trimming behaviour
- update implementation status docs

## Testing
- `cargo fmt --all -- --check` *(fails: `cargo-fmt` is missing)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: `cargo-clippy` is missing)*
- `cargo test --workspace --offline` *(fails: could not fetch crates)*
