### PR TITLE
Implement Gate.io rate limiter

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -737,7 +737,7 @@ Exchanges currently implementing the `Canonicalizer` trait:
 - [x] OKX: Exchange-specific rate limiting implemented for REST and WebSocket.
 - [x] Hyperliquid: Exchange-specific rate limiting implemented for REST and WebSocket.
 - [ ] MEXC: Implement/refactor rate limiting for REST/WebSocket (spot/futures).
-- [ ] Gate.io: Implement/refactor rate limiting for REST/WebSocket (spot/futures).
+- [x] Gate.io: Exchange-specific rate limiting implemented for REST and WebSocket.
 - [ ] Crypto.com: Implement/refactor rate limiting for REST/WebSocket (spot/futures).
 
 **Final Steps:**

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -23,6 +23,7 @@ Rate limit modules are implemented for:
 - Bitget
 - Bybit
 - Coinbase
+- Gate.io
 - Hyperliquid
 - Kraken
 - OKX

--- a/jackbot-data/src/exchange/gateio/mod.rs
+++ b/jackbot-data/src/exchange/gateio/mod.rs
@@ -1,0 +1,10 @@
+//! Gate.io exchange module.
+
+/// Spot market modules for Gate.io.
+pub mod spot;
+/// Futures market modules for Gate.io.
+pub mod futures;
+/// Trade event types for Gate.io.
+pub mod trade;
+/// Rate limiting utilities for Gate.io.
+pub mod rate_limit;

--- a/jackbot-data/src/exchange/gateio/rate_limit.rs
+++ b/jackbot-data/src/exchange/gateio/rate_limit.rs
@@ -1,0 +1,87 @@
+use jackbot_integration::rate_limit::{Priority, RateLimiter};
+use std::time::Duration;
+
+/// Gate.io API rate limiter for REST and WebSocket usage.
+#[derive(Clone)]
+pub struct GateioRateLimit {
+    rest: RateLimiter,
+    ws: RateLimiter,
+}
+
+impl GateioRateLimit {
+    /// Create a new [`GateioRateLimit`] using placeholder quotas.
+    ///
+    /// REST: 900 requests per minute.
+    /// WebSocket: 20 messages per second.
+    pub fn new() -> Self {
+        Self::with_params(
+            900,
+            Duration::from_secs(60),
+            20,
+            Duration::from_secs(1),
+            Duration::from_millis(100),
+        )
+    }
+
+    /// Create a custom [`GateioRateLimit`] with provided quotas and jitter for testing.
+    pub fn with_params(
+        rest_capacity: usize,
+        rest_interval: Duration,
+        ws_capacity: usize,
+        ws_interval: Duration,
+        jitter: Duration,
+    ) -> Self {
+        Self {
+            rest: RateLimiter::new_with_jitter(rest_capacity, rest_interval, jitter),
+            ws: RateLimiter::new_with_jitter(ws_capacity, ws_interval, jitter),
+        }
+    }
+
+    /// Acquire a REST permit with the specified [`Priority`].
+    pub async fn acquire_rest(&self, priority: Priority) {
+        self.rest.acquire(priority).await;
+    }
+
+    /// Acquire a WebSocket permit with the specified [`Priority`].
+    pub async fn acquire_ws(&self, priority: Priority) {
+        self.ws.acquire(priority).await;
+    }
+
+    /// Report a REST rate limit violation.
+    pub async fn report_rest_violation(&self) {
+        self.rest.report_violation().await;
+    }
+
+    /// Report a WebSocket rate limit violation.
+    pub async fn report_ws_violation(&self) {
+        self.ws.report_violation().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackbot_integration::rate_limit::Priority;
+    use tokio::time::{Duration, Instant};
+
+    #[tokio::test]
+    async fn test_rest_limit_exhaustion() {
+        let rl = GateioRateLimit::with_params(1, Duration::from_millis(40), 1, Duration::from_millis(40), Duration::from_millis(0));
+        rl.acquire_rest(Priority::Normal).await;
+        let start = Instant::now();
+        rl.acquire_rest(Priority::Normal).await;
+        assert!(start.elapsed() >= Duration::from_millis(40));
+    }
+
+    #[tokio::test]
+    async fn test_ws_backoff_jitter() {
+        let rl = GateioRateLimit::with_params(1, Duration::from_millis(20), 1, Duration::from_millis(20), Duration::from_millis(20));
+        rl.acquire_ws(Priority::Normal).await;
+        rl.report_ws_violation().await;
+        let start = Instant::now();
+        rl.acquire_ws(Priority::Normal).await;
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(40));
+        assert!(elapsed <= Duration::from_millis(60));
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated Gate.io rate limiter module
- expose rate limiting from the Gate.io exchange module
- document Gate.io rate limit status and update exchange list

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt component not installed)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy component not installed)*
- `cargo test --workspace` *(fails: couldn't fetch crates)*
