### PR TITLE
Add market making abstraction documentation and trait

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -892,7 +892,7 @@ Exchanges currently implementing the `Canonicalizer` trait:
 > **Goal:** Implement a high-performance market making engine for providing liquidity across all supported exchanges and markets. Support advanced features like inventory management, skew adjustment, spread optimization, and adverse selection mitigation with robust risk controls and performance tracking.
 
 **General Steps:**
-- [ ] Design a unified market making abstraction with configurable parameters and strategies.
+ - [x] Design a unified market making abstraction with configurable parameters and strategies. See [MARKET_MAKING_ABSTRACTION.md](MARKET_MAKING_ABSTRACTION.md).
 - [x] Implement efficient two-sided quote management (bid/ask placement, monitoring, adjustment).
 - [x] Create inventory management and skew adjustment algorithms.
 - [x] Implement spread optimization based on volatility, competition, and flow toxicity.

--- a/docs/MARKET_MAKING_ABSTRACTION.md
+++ b/docs/MARKET_MAKING_ABSTRACTION.md
@@ -1,0 +1,39 @@
+# Market Making Abstraction
+
+Market making strategies often share common behaviour but implementations vary by exchange. This document introduces a simple trait for building market makers in a consistent way.
+
+## Goals
+- Provide a single trait to drive quoting algorithms.
+- Keep implementations exchange agnostic by building on `ExecutionClient`.
+- Allow strategies to expose custom configuration parameters.
+
+## `MarketMakingStrategy`
+```rust
+use async_trait::async_trait;
+use jackbot_execution::{
+    client::ExecutionClient,
+    error::UnindexedClientError,
+    market_making::Quote,
+};
+
+#[async_trait]
+pub trait MarketMakingStrategy<C>
+where
+    C: ExecutionClient + Clone + Send + Sync,
+{
+    /// Additional configuration required by the strategy.
+    type Config: Send + Sync;
+
+    /// Maintain markets using the provided execution client and configuration.
+    async fn maintain_market(
+        &mut self,
+        client: &C,
+        config: Self::Config,
+    ) -> Result<Quote, UnindexedClientError>;
+}
+```
+
+Implementations may place, cancel or modify orders via `ExecutionClient` while retaining their own quoting logic. The `Config` associated type allows strategies to declare parameters such as target spread, inventory limits or refresh intervals.
+
+## Initial Implementation
+`InventorySkewQuoter` and related components can be adapted to this trait. Future exchange-specific strategies can reuse the same interface for consistent behaviour across markets.

--- a/jackbot-execution/src/market_making/mod.rs
+++ b/jackbot-execution/src/market_making/mod.rs
@@ -2,6 +2,28 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use derive_more::Constructor;
 use chrono::{DateTime, Duration, Utc};
+use async_trait::async_trait;
+use crate::{client::ExecutionClient, error::UnindexedClientError};
+
+/// Unified interface for market making strategies.
+///
+/// Implementations should place, cancel or adjust orders using an
+/// [`ExecutionClient`] while keeping the quoting logic exchange agnostic.
+#[async_trait]
+pub trait MarketMakingStrategy<C>
+where
+    C: ExecutionClient + Clone + Send + Sync,
+{
+    /// Additional configuration required by the strategy.
+    type Config: Send + Sync;
+
+    /// Maintain markets using the provided client and configuration.
+    async fn maintain_market(
+        &mut self,
+        client: &C,
+        config: Self::Config,
+    ) -> Result<Quote, UnindexedClientError>;
+}
 
 /// Quote prices maintained by the market making logic.
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize, Constructor)]


### PR DESCRIPTION
## Summary
- document new `MarketMakingStrategy` abstraction
- mark market making abstraction step complete in implementation status
- add `MarketMakingStrategy` trait to market_making module

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt component missing)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy component missing)*
- `cargo test --workspace` *(fails: could not download crates)*
