### PR TITLE
Add backtesting integration tests

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -758,7 +758,7 @@ Exchanges currently implementing the `Canonicalizer` trait:
 - [x] Implement performance metrics calculation and reporting (P&L, Sharpe, drawdown, etc.).
 - [x] Add visualization and charting capabilities for backtest results.
 - [x] Support parallel backtesting for parameter optimization and Monte Carlo simulations.
-- [ ] Add/extend integration and unit tests for backtesting framework components.
+- [x] Add/extend integration and unit tests for backtesting framework components.
 - [x] Add/extend module-level and user-facing documentation.
 - [x] Update `docs/IMPLEMENTATION_STATUS.md` with status and links.
 

--- a/jackbot/tests/test_backtest_metrics.rs
+++ b/jackbot/tests/test_backtest_metrics.rs
@@ -1,0 +1,77 @@
+use Jackbot::{
+    backtest::{backtest, BacktestArgsConstant, BacktestArgsDynamic, market_data::MarketDataInMemory},
+    engine::{state::{EngineState, builder::EngineStateBuilder, global::DefaultGlobalData, instrument::data::DefaultInstrumentMarketData, trading::TradingState}},
+    risk::DefaultRiskManager,
+    strategy::DefaultStrategy,
+    statistic::time::Daily,
+    system::config::ExecutionConfig,
+};
+use jackbot_data::{event::{MarketEvent, DataKind}, streams::consumer::MarketStreamEvent, subscription::trade::PublicTrade};
+use jackbot_execution::{client::mock::MockExecutionConfig, AccountSnapshot};
+use jackbot_instrument::{exchange::ExchangeId, index::IndexedInstruments, instrument::{Instrument, InstrumentIndex}, Side, Underlying};
+use rust_decimal::Decimal;
+use chrono::{Utc, Duration};
+use smol_str::SmolStr;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn test_backtest_trading_duration() {
+    // fixed times for determinism
+    let start = Utc::now();
+    let events = vec![
+        MarketStreamEvent::Item(MarketEvent {
+            time_exchange: start,
+            time_received: start,
+            exchange: ExchangeId::BinanceSpot,
+            instrument: InstrumentIndex(0),
+            kind: DataKind::Trade(PublicTrade { id: "1".into(), price: 100.0, amount: 1.0, side: Side::Buy }),
+        }),
+        MarketStreamEvent::Item(MarketEvent {
+            time_exchange: start + Duration::seconds(1),
+            time_received: start + Duration::seconds(1),
+            exchange: ExchangeId::BinanceSpot,
+            instrument: InstrumentIndex(0),
+            kind: DataKind::Trade(PublicTrade { id: "2".into(), price: 101.0, amount: 1.0, side: Side::Buy }),
+        }),
+    ];
+    let market_data = MarketDataInMemory::new(Arc::new(events));
+    let time_engine_start = market_data.time_first_event().await.unwrap();
+
+    let instruments = IndexedInstruments::builder()
+        .add_instrument(Instrument::spot(
+            ExchangeId::BinanceSpot,
+            "binance_spot_btc_usdt",
+            "BTCUSDT",
+            Underlying::new("btc", "usdt"),
+            None,
+        ))
+        .build();
+
+    let engine_state: EngineState<DefaultGlobalData, DefaultInstrumentMarketData> =
+        EngineStateBuilder::new(&instruments, DefaultGlobalData::default(), DefaultInstrumentMarketData::default)
+            .time_engine_start(time_engine_start)
+            .trading_state(TradingState::Enabled)
+            .build();
+
+    let execution_snapshot = AccountSnapshot { exchange: ExchangeId::BinanceSpot, balances: Vec::new(), instruments: Vec::new() };
+    let executions = vec![ExecutionConfig::Mock(MockExecutionConfig { mocked_exchange: ExchangeId::BinanceSpot, initial_state: execution_snapshot, latency_ms: 0, fees_percent: Decimal::ZERO })];
+
+    let args_constant = Arc::new(BacktestArgsConstant {
+        instruments,
+        executions,
+        market_data,
+        summary_interval: Daily,
+        engine_state,
+    });
+
+    let args_dynamic = BacktestArgsDynamic {
+        id: SmolStr::new("duration"),
+        risk_free_return: Decimal::ZERO,
+        strategy: DefaultStrategy::<EngineState<DefaultGlobalData, DefaultInstrumentMarketData>>::default(),
+        risk: DefaultRiskManager::<EngineState<DefaultGlobalData, DefaultInstrumentMarketData>>::default(),
+    };
+
+    let summary = backtest(args_constant, args_dynamic).await.expect("backtest");
+    assert_eq!(summary.id, SmolStr::new("duration"));
+    assert_eq!(summary.trading_summary.trading_duration().num_seconds(), 1);
+}

--- a/jackbot/tests/test_order_book_replay.rs
+++ b/jackbot/tests/test_order_book_replay.rs
@@ -1,0 +1,29 @@
+use Jackbot::backtest::order_book_replay::OrderBookReplay;
+use jackbot_data::{books::{OrderBook}, subscription::book::OrderBookEvent};
+use rust_decimal_macros::dec;
+
+#[test]
+fn test_order_book_replay_updates_book() {
+    // initial snapshot with one bid and ask
+    let snapshot = OrderBook::new(
+        0,
+        None,
+        vec![(dec!(100), dec!(1))],
+        vec![(dec!(101), dec!(1))],
+    );
+
+    let mut replay = OrderBookReplay::new(snapshot);
+
+    // update event replaces levels
+    let update = OrderBook::new(
+        1,
+        None,
+        vec![(dec!(102), dec!(2))],
+        vec![(dec!(103), dec!(2))],
+    );
+    replay.apply(OrderBookEvent::Update(update));
+
+    let book = replay.current();
+    assert_eq!(book.bids().levels()[0].price, dec!(102));
+    assert_eq!(book.asks().levels()[0].price, dec!(103));
+}

--- a/jackbot/tests/test_pnl_returns.rs
+++ b/jackbot/tests/test_pnl_returns.rs
@@ -1,0 +1,29 @@
+use Jackbot::statistic::summary::pnl::PnLReturns;
+use Jackbot::engine::state::position::PositionExited;
+use jackbot_execution::trade::{TradeId, AssetFees};
+use jackbot_instrument::{asset::QuoteAsset, instrument::InstrumentIndex, Side};
+use chrono::Utc;
+use rust_decimal_macros::dec;
+
+#[test]
+fn test_pnl_returns_update() {
+    let mut pnl = PnLReturns::default();
+    let position = PositionExited {
+        instrument: InstrumentIndex(0),
+        side: Side::Buy,
+        price_entry_average: dec!(100),
+        quantity_abs_max: dec!(1),
+        pnl_realised: dec!(10),
+        fees_enter: AssetFees::quote_fees(dec!(0)),
+        fees_exit: AssetFees::quote_fees(dec!(0)),
+        time_enter: Utc::now(),
+        time_exit: Utc::now(),
+        trades: vec![TradeId::new("t1")],
+    };
+
+    pnl.update(&position);
+
+    assert_eq!(pnl.pnl_raw, dec!(10));
+    assert_eq!(pnl.total.count, dec!(1));
+    assert_eq!(pnl.losses.count, dec!(0));
+}


### PR DESCRIPTION
## Summary
- add order book replay test
- add backtest duration metrics test
- add PnL returns metric test
- mark backtesting tests complete in docs

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt component missing)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy component missing)*
- `cargo test --workspace` *(fails: could not fetch crates due to network)*