### PR TITLE
Implement WS health monitor abstraction

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -673,7 +673,7 @@ Exchanges currently implementing the `Canonicalizer` trait:
 > **Goal:** Implement robust health monitoring and auto-reconnection logic for all WebSocket connections across all exchanges and markets. Ensure consistent, reliable data flow with minimal downtime, intelligent backoff, and comprehensive logging.
 
 **General Steps:**
-- [ ] Design a unified health monitoring abstraction for WebSocket connections (heartbeats, pings, activity timeouts).
+- [x] Design a unified health monitoring abstraction for WebSocket connections (heartbeats, pings, activity timeouts).
 - [ ] Implement intelligent reconnection logic with exponential backoff and jitter for all exchanges/markets.
 - [ ] Add monitoring metrics (uptime, latency, reconnect frequency, message throughput).
 - [ ] Implement connection lifecycle events and error classification.

--- a/jackbot-data/tests/binance_reconnect.rs
+++ b/jackbot-data/tests/binance_reconnect.rs
@@ -1,6 +1,7 @@
 use tokio_stream::{StreamExt as TokioStreamExt};
 use futures::StreamExt;
-use jackbot_integration::protocol::websocket::{WsMessage, WsError};
+use jackbot_integration::protocol::websocket::{WsMessage, WsError, with_heartbeat};
+use jackbot_instrument::exchange::ExchangeId;
 use std::time::Duration;
 use std::io;
 
@@ -8,12 +9,11 @@ use std::io;
 async fn test_heartbeat_timeout_results_in_error() {
     tokio::time::pause();
 
-    let stream = tokio_stream::pending::<Result<WsMessage, WsError>>()
-        .timeout(Duration::from_secs(1))
-        .map(|res| match res {
-            Ok(msg) => msg,
-            Err(_) => Err(WsError::Io(io::Error::new(io::ErrorKind::TimedOut, "heartbeat timeout"))),
-        });
+    let stream = with_heartbeat(
+        tokio_stream::pending::<Result<WsMessage, WsError>>(),
+        Duration::from_secs(1),
+        ExchangeId::BinanceSpot,
+    );
 
     tokio::pin!(stream);
 


### PR DESCRIPTION
## Summary
- add `with_heartbeat` helper for WebSocket monitoring
- use new abstraction in `jackbot-data`
- adjust reconnect test
- mark health monitoring abstraction completed in docs

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt component missing)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy component missing)*
- `cargo test --workspace` *(fails: could not download crates)*