### PR TITLE
Add advanced order type summary

### DIFF
--- a/docs/ADVANCED_ORDER_TYPE_SUPPORT.md
+++ b/docs/ADVANCED_ORDER_TYPE_SUPPORT.md
@@ -1,0 +1,56 @@
+# Advanced Order Type Support
+
+This document summarises the current support for advanced order types across all exchanges integrated with Jackbot. Where a venue lacks native support, Jackbot emulates the behaviour via the execution client layer.
+
+## Features Considered
+
+- **Always Maker** – post-only orders placed at the top of book and automatically cancelled or reposted when the price moves.
+- **Advanced TWAP** – time-weighted execution using non-linear schedules and order book blending.
+- **Advanced VWAP** – volume-weighted execution based on observed market volume patterns.
+- **Smart Trades** – trailing take profit, fixed profit targets, trailing stop loss and multi-level stop loss.
+- **Prophetic Orders** – capture out-of-book limit orders and place them once the market trades within range.
+- **Jackpot Orders** – high leverage bets with strictly controlled ticket loss.
+
+## Exchange Matrix
+
+| Exchange | Always Maker | TWAP/VWAP | Smart Trades | Prophetic Orders | Jackpot Orders | Notes |
+|---------|--------------|-----------|--------------|------------------|----------------|-------|
+| Binance | Yes | Yes | Yes | Yes | Yes | |
+| Bitget | Yes | Yes | Yes | Yes | Yes | |
+| Bybit | Yes | Yes | Yes | Yes | Yes | |
+| Coinbase | Yes | Yes | Yes | Yes | N/A | Spot only |
+| Hyperliquid | Yes | Yes | Yes | Yes | Yes | |
+| Kraken | Yes | Yes | Yes | Yes | Yes | |
+| MEXC | Yes | Yes | Yes | Yes | Stub | Jackpot API pending |
+| Kucoin | Yes | Yes | Yes | Yes | Yes | |
+| Gate.io | Yes | Yes | Yes | Yes | Stub | Jackpot API pending |
+| Crypto.com | Yes | Yes | Yes | Yes | Stub | Jackpot API pending |
+| OKX | Yes | Yes | Yes | Yes | Yes | |
+
+All exchanges expose the same trait-based interface in `jackbot-execution`. Stubs indicate planned integration where the exchange API does not yet offer an equivalent feature.
+
+## Unified Abstraction Design
+
+Advanced order types share common behaviours: splitting orders, scheduling placements and monitoring state. To encourage consistency each exchange implementation should provide an `AdvancedOrderExecutor` built on top of `ExecutionClient`:
+
+```rust
+use async_trait::async_trait;
+use jackbot_execution::order::{request::OrderRequestOpen, state::Open, Order};
+use jackbot_execution::error::UnindexedOrderError;
+use jackbot_instrument::{exchange::ExchangeId, instrument::name::InstrumentNameExchange};
+
+#[async_trait]
+pub trait AdvancedOrderExecutor {
+    async fn always_maker(&mut self, req: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>)
+        -> Result<Order<ExchangeId, InstrumentNameExchange, Open>, UnindexedOrderError>;
+
+    async fn twap(&mut self, req: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>, config: twap::TwapConfig)
+        -> Vec<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>>;
+
+    async fn vwap(&mut self, req: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>, config: vwap::VwapConfig)
+        -> Vec<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>>;
+}
+```
+
+`PropheticOrderManager`, `JackpotOrderManager` and the various smart trade helpers plug into this executor to provide exchange‑agnostic advanced orders. Each exchange adaptor is free to optimize the underlying calls while keeping the surface consistent.
+

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -353,8 +353,8 @@ Exchanges currently implementing the `Canonicalizer` trait:
 > **Goal:** Implement advanced smart trade features for all supported exchanges and both live/paper trading: trailing take profit, profit at predetermined price levels, trailing stop loss, and multi-level stop loss. Ensure robust abstraction, event handling, and test coverage.
 
 **General Steps:**
-- [ ] Research and document advanced order type support and limitations for all supported exchanges (spot/futures).
-- [ ] Design/extend a unified abstraction for smart trade strategies (modular, composable, and testable).
+ - [x] Research and document advanced order type support and limitations for all supported exchanges (spot/futures). See `docs/ADVANCED_ORDER_TYPE_SUPPORT.md`.
+ - [ ] Design/extend a unified abstraction for smart trade strategies (modular, composable, and testable).
 - [x] Implement trailing take profit logic (dynamic adjustment as price moves in favor).
 - [x] Implement profit at predetermined price levels (partial or full closes at set targets).
 - [x] Implement trailing stop loss logic (dynamic stop that follows price).


### PR DESCRIPTION
## Summary
- document support for advanced order types across all exchanges
- link new summary in implementation status checklist

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt not installed)*