### PR TITLE
Implement trade stream aliases across exchanges

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -247,6 +247,7 @@ Exchanges currently implementing the `Canonicalizer` trait:
 - All L1 types, subscription kinds, and references have been deleted from the codebase.
 - Example files dedicated to L1 streams have also been removed.
 - Added `TRADE_WS_ENDPOINTS.md` summarising trade WebSocket endpoints.
+- Scaffolding baseline trade WebSocket modules across exchanges.
 
 ## Current Features
 

--- a/jackbot-data/src/exchange/coinbase/spot/trade.rs
+++ b/jackbot-data/src/exchange/coinbase/spot/trade.rs
@@ -1,3 +1,23 @@
 //! Trade event types for Coinbase Spot.
+//!
+//! Provides type aliases for working with [`Coinbase`](super::super::super::Coinbase)
+//! trade WebSocket streams.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::super::super::Coinbase;
+
+pub use super::super::trade::CoinbaseTrade;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Coinbase WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type CoinbaseSpotTradesTransformer<InstrumentKey> =
+    StatelessTransformer<Coinbase, InstrumentKey, PublicTrades, CoinbaseTrade>;
+
+/// Type alias for a Coinbase Spot trades WebSocket stream.
+pub type CoinbaseSpotTradesStream<InstrumentKey> =
+    ExchangeWsStream<CoinbaseSpotTradesTransformer<InstrumentKey>>;

--- a/jackbot-data/src/exchange/hyperliquid/futures/trade.rs
+++ b/jackbot-data/src/exchange/hyperliquid/futures/trade.rs
@@ -1,3 +1,23 @@
 //! Trade event types for Hyperliquid Futures.
+//!
+//! Provides convenient aliases for [`Hyperliquid`](super::super::super::Hyperliquid)
+//! futures trade streams.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::super::super::Hyperliquid;
+
+pub use super::super::trade::HyperliquidTrades;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Hyperliquid WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type HyperliquidFuturesTradesTransformer<InstrumentKey> =
+    StatelessTransformer<Hyperliquid, InstrumentKey, PublicTrades, HyperliquidTrades>;
+
+/// Type alias for a Hyperliquid Futures trades WebSocket stream.
+pub type HyperliquidFuturesTradesStream<InstrumentKey> =
+    ExchangeWsStream<HyperliquidFuturesTradesTransformer<InstrumentKey>>;

--- a/jackbot-data/src/exchange/hyperliquid/spot/trade.rs
+++ b/jackbot-data/src/exchange/hyperliquid/spot/trade.rs
@@ -1,3 +1,23 @@
 //! Trade event types for Hyperliquid Spot.
+//!
+//! Provides convenient aliases for [`Hyperliquid`](super::super::super::Hyperliquid)
+//! trade streams.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::super::super::Hyperliquid;
+
+pub use super::super::trade::HyperliquidTrades;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Hyperliquid WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type HyperliquidSpotTradesTransformer<InstrumentKey> =
+    StatelessTransformer<Hyperliquid, InstrumentKey, PublicTrades, HyperliquidTrades>;
+
+/// Type alias for a Hyperliquid Spot trades WebSocket stream.
+pub type HyperliquidSpotTradesStream<InstrumentKey> =
+    ExchangeWsStream<HyperliquidSpotTradesTransformer<InstrumentKey>>;

--- a/jackbot-data/src/exchange/kraken/futures/trade.rs
+++ b/jackbot-data/src/exchange/kraken/futures/trade.rs
@@ -1,3 +1,22 @@
 //! Trade event types for Kraken Futures.
+//!
+//! Provides convenient aliases for [`Kraken`](super::super::super::Kraken) futures trade streams.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::super::super::Kraken;
+
+pub use super::super::trade::KrakenTrades;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Kraken WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type KrakenFuturesTradesTransformer<InstrumentKey> =
+    StatelessTransformer<Kraken, InstrumentKey, PublicTrades, KrakenTrades>;
+
+/// Type alias for a Kraken Futures trades WebSocket stream.
+pub type KrakenFuturesTradesStream<InstrumentKey> =
+    ExchangeWsStream<KrakenFuturesTradesTransformer<InstrumentKey>>;

--- a/jackbot-data/src/exchange/kraken/spot/trade.rs
+++ b/jackbot-data/src/exchange/kraken/spot/trade.rs
@@ -1,3 +1,22 @@
 //! Trade event types for Kraken Spot.
+//!
+//! Provides convenient aliases for [`Kraken`](super::super::super::Kraken) trade streams.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::super::super::Kraken;
+
+pub use super::super::trade::KrakenTrades;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Kraken WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type KrakenSpotTradesTransformer<InstrumentKey> =
+    StatelessTransformer<Kraken, InstrumentKey, PublicTrades, KrakenTrades>;
+
+/// Type alias for a Kraken Spot trades WebSocket stream.
+pub type KrakenSpotTradesStream<InstrumentKey> =
+    ExchangeWsStream<KrakenSpotTradesTransformer<InstrumentKey>>;

--- a/jackbot-data/src/exchange/kucoin/futures/trade.rs
+++ b/jackbot-data/src/exchange/kucoin/futures/trade.rs
@@ -1,3 +1,22 @@
 //! Trade event types for Kucoin Futures.
+//!
+//! Provides convenient aliases for [`Kucoin`](super::super::super::Kucoin) futures trade streams.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::super::super::Kucoin;
+
+pub use super::super::trade::KucoinTrade;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Kucoin WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type KucoinFuturesTradesTransformer<InstrumentKey> =
+    StatelessTransformer<Kucoin, InstrumentKey, PublicTrades, KucoinTrade>;
+
+/// Type alias for a Kucoin Futures trades WebSocket stream.
+pub type KucoinFuturesTradesStream<InstrumentKey> =
+    ExchangeWsStream<KucoinFuturesTradesTransformer<InstrumentKey>>;

--- a/jackbot-data/src/exchange/kucoin/spot/trade.rs
+++ b/jackbot-data/src/exchange/kucoin/spot/trade.rs
@@ -1,3 +1,22 @@
 //! Trade event types for Kucoin Spot.
+//!
+//! Provides convenient aliases for [`Kucoin`](super::super::super::Kucoin) trade streams.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::super::super::Kucoin;
+
+pub use super::super::trade::KucoinTrade;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Kucoin WebSocket trade messages into [`PublicTrade`](PublicTrades)
+/// events.
+pub type KucoinSpotTradesTransformer<InstrumentKey> =
+    StatelessTransformer<Kucoin, InstrumentKey, PublicTrades, KucoinTrade>;
+
+/// Type alias for a Kucoin Spot trades WebSocket stream.
+pub type KucoinSpotTradesStream<InstrumentKey> =
+    ExchangeWsStream<KucoinSpotTradesTransformer<InstrumentKey>>;

--- a/jackbot-data/src/exchange/okx/futures/trade.rs
+++ b/jackbot-data/src/exchange/okx/futures/trade.rs
@@ -1,3 +1,21 @@
 //! Trade event types for Okx Futures.
+//!
+//! Provides convenient aliases for [`Okx`](super::super::super::Okx) futures trade streams.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::super::super::Okx;
+
+pub use super::super::trade::OkxTrades;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Okx WebSocket trade messages into [`PublicTrade`](PublicTrades) events.
+pub type OkxFuturesTradesTransformer<InstrumentKey> =
+    StatelessTransformer<Okx, InstrumentKey, PublicTrades, OkxTrades>;
+
+/// Type alias for an Okx Futures trades WebSocket stream.
+pub type OkxFuturesTradesStream<InstrumentKey> =
+    ExchangeWsStream<OkxFuturesTradesTransformer<InstrumentKey>>;

--- a/jackbot-data/src/exchange/okx/spot/trade.rs
+++ b/jackbot-data/src/exchange/okx/spot/trade.rs
@@ -1,3 +1,21 @@
 //! Trade event types for Okx Spot.
+//!
+//! Provides convenient aliases for [`Okx`](super::super::super::Okx) trade streams.
 
-pub use super::super::trade::*;
+use crate::{
+    transformer::stateless::StatelessTransformer,
+    subscription::trade::PublicTrades,
+    ExchangeWsStream,
+};
+use super::super::super::Okx;
+
+pub use super::super::trade::OkxTrades;
+
+/// [`ExchangeTransformer`](crate::transformer::ExchangeTransformer) used to
+/// convert Okx WebSocket trade messages into [`PublicTrade`](PublicTrades) events.
+pub type OkxSpotTradesTransformer<InstrumentKey> =
+    StatelessTransformer<Okx, InstrumentKey, PublicTrades, OkxTrades>;
+
+/// Type alias for an Okx Spot trades WebSocket stream.
+pub type OkxSpotTradesStream<InstrumentKey> =
+    ExchangeWsStream<OkxSpotTradesTransformer<InstrumentKey>>;


### PR DESCRIPTION
## Summary
- scaffold baseline trade WS modules for multiple exchanges
- add public type aliases for trade transformers and streams
- document recent changes in implementation status

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt not installed)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy not installed)*
- `cargo test --workspace` *(fails: could not download crates)*