### PR TITLE
Implement liquidation normalization stubs

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -12,6 +12,8 @@
 * Gate.io
 * Crypto.com
 * OKX
+  - OKX does not provide a public liquidations WebSocket channel. The code
+    includes a stub at `jackbot-data/src/exchange/okx/liquidation.rs`.
 
 **Instructions for Contributors:**
 - Check off each box as you complete the step for each task.

--- a/jackbot-data/src/exchange/bitget/liquidation.rs
+++ b/jackbot-data/src/exchange/bitget/liquidation.rs
@@ -1,15 +1,128 @@
 //! Liquidation event types and parsing for Bitget exchange.
 
-#[derive(Debug, Clone)]
-pub struct BitgetLiquidation;
+use crate::{
+    event::{MarketEvent, MarketIter},
+    Identifier,
+    subscription::liquidation::Liquidation,
+};
+use chrono::{DateTime, Utc};
+use jackbot_instrument::{exchange::ExchangeId, Side};
+use jackbot_integration::subscription::SubscriptionId;
+use serde::{Deserialize, Serialize};
+
+/// Bitget liquidation order message.
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct BitgetLiquidation {
+    #[serde(alias = "instId", deserialize_with = "de_liquidation_subscription_id")]
+    pub subscription_id: SubscriptionId,
+    #[serde(alias = "px", alias = "price", deserialize_with = "jackbot_integration::de::de_str")]
+    pub price: f64,
+    #[serde(alias = "sz", alias = "size", deserialize_with = "jackbot_integration::de::de_str")]
+    pub quantity: f64,
+    #[serde(deserialize_with = "de_side")]
+    pub side: Side,
+    #[serde(
+        alias = "ts",
+        alias = "timestamp",
+        deserialize_with = "jackbot_integration::de::de_str_u64_epoch_ms_as_datetime_utc",
+    )]
+    pub time: DateTime<Utc>,
+}
+
+impl Identifier<Option<SubscriptionId>> for BitgetLiquidation {
+    fn id(&self) -> Option<SubscriptionId> {
+        Some(self.subscription_id.clone())
+    }
+}
+
+impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BitgetLiquidation)>
+    for MarketIter<InstrumentKey, Liquidation>
+{
+    fn from(
+        (exchange_id, instrument, liquidation): (ExchangeId, InstrumentKey, BitgetLiquidation),
+    ) -> Self {
+        Self(vec![Ok(MarketEvent {
+            time_exchange: liquidation.time,
+            time_received: Utc::now(),
+            exchange: exchange_id,
+            instrument,
+            kind: Liquidation {
+                side: liquidation.side,
+                price: liquidation.price,
+                quantity: liquidation.quantity,
+                time: liquidation.time,
+            },
+        })])
+    }
+}
 
 impl BitgetLiquidation {
-    pub fn normalize(&self) {
-        // TODO: implement normalization
+    /// Convert the Bitget message into the standard [`Liquidation`] type.
+    pub fn normalize(&self) -> Liquidation {
+        Liquidation {
+            side: self.side,
+            price: self.price,
+            quantity: self.quantity,
+            time: self.time,
+        }
+    }
+}
+
+/// Deserialize a [`BitgetLiquidation`] market field into a [`SubscriptionId`].
+pub fn de_liquidation_subscription_id<'de, D>(deserializer: D) -> Result<SubscriptionId, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    <&str as Deserialize>::deserialize(deserializer)
+        .map(|market| SubscriptionId::from(format!("liquidation|{}", market)))
+}
+
+/// Deserialize a liquidation side as a [`Side`].
+fn de_side<'de, D>(deserializer: D) -> Result<Side, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let side = <&str as Deserialize>::deserialize(deserializer)?.to_ascii_lowercase();
+    match side.as_str() {
+        "buy" | "long" => Ok(Side::Buy),
+        "sell" | "short" => Ok(Side::Sell),
+        _ => Err(serde::de::Error::custom(format!(
+            "Failed to deserialize Bitget liquidation side: {}",
+            side
+        ))),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    // TODO: add tests
+    use super::*;
+    use jackbot_integration::de::datetime_utc_from_epoch_duration;
+    use std::time::Duration;
+
+    #[test]
+    fn test_bitget_liquidation_deserialize_and_normalize() {
+        let json = r#"{
+            \"instId\": \"BTCUSDT_UMCBL\",
+            \"px\": \"42000\",
+            \"sz\": \"0.01\",
+            \"side\": \"sell\",
+            \"ts\": \"1717000000000\"
+        }"#;
+
+        let liq: BitgetLiquidation = serde_json::from_str(json).unwrap();
+
+        assert_eq!(liq.subscription_id.as_str(), "liquidation|BTCUSDT_UMCBL");
+        assert_eq!(liq.price, 42000.0);
+        assert_eq!(liq.quantity, 0.01);
+        assert_eq!(liq.side, Side::Sell);
+        assert_eq!(
+            liq.time,
+            datetime_utc_from_epoch_duration(Duration::from_millis(1717000000000))
+        );
+
+        let normal = liq.normalize();
+        assert_eq!(normal.price, 42000.0);
+        assert_eq!(normal.quantity, 0.01);
+        assert_eq!(normal.side, Side::Sell);
+    }
 }

--- a/jackbot-data/src/exchange/okx/liquidation.rs
+++ b/jackbot-data/src/exchange/okx/liquidation.rs
@@ -1,4 +1,4 @@
-use crate::subscription::liquidation::Liquidations;
+use crate::subscription::liquidation::Liquidation;
 use jackbot_integration::subscription::SubscriptionId;
 
 /// OKX does not support a public liquidations channel as of 2024-06.
@@ -6,8 +6,14 @@ use jackbot_integration::subscription::SubscriptionId;
 pub struct OkxLiquidation;
 
 impl OkxLiquidation {
+    /// OKX does not expose liquidation events publicly.
     pub fn from_message(_msg: &str) -> Option<()> {
         // No public liquidations channel on OKX
+        None
+    }
+
+    /// Normalization helper that always returns `None`.
+    pub fn normalize(&self) -> Option<Liquidation> {
         None
     }
 }
@@ -18,4 +24,16 @@ impl crate::Identifier<Option<SubscriptionId>> for OkxLiquidation {
     }
 }
 
-// TODO: Implement normalization from raw OKX messages to Liquidation
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_okx_liquidation_stub() {
+        let liq = OkxLiquidation;
+        assert!(liq.normalize().is_none());
+        assert!(OkxLiquidation::from_message("{}").is_none());
+        assert!(liq.id().is_none());
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `BitgetLiquidation` parsing and normalization with tests
- add stub normalization for OKX liquidations and corresponding tests
- document missing OKX liquidations channel in implementation status

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt component missing)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy component missing)*
- `cargo test --workspace` *(fails: could not fetch crates)*