### PR TITLE
Document post-only maker support

### DIFF
--- a/docs/ADVANCED_ORDER_TYPE_SUPPORT.md
+++ b/docs/ADVANCED_ORDER_TYPE_SUPPORT.md
@@ -29,6 +29,26 @@ This document summarises the current support for advanced order types across all
 
 All exchanges expose the same trait-based interface in `jackbot-execution`. Stubs indicate planned integration where the exchange API does not yet offer an equivalent feature.
 
+## Maker-Only (Post-Only) Support
+
+Some advanced execution algorithms rely on placing maker-only orders. The table below summarises native post-only capabilities across supported venues. Where a venue lacks a direct API flag, Jackbot emulates the behaviour by cancelling and reposting orders when they would otherwise match as takers.
+
+| Exchange | Spot Post-Only | Futures Post-Only | Notes |
+|----------|----------------|-------------------|-------|
+| Binance | Yes | Yes | |
+| Bitget | Yes | Yes | |
+| Bybit | Yes | Yes | |
+| Coinbase | Yes | N/A | Spot only venue |
+| Hyperliquid | N/A | Yes | Perpetual markets only |
+| Kraken | Yes | Yes | |
+| MEXC | Yes | Yes | |
+| Kucoin | Yes | Yes | |
+| Gate.io | Yes | Yes | |
+| Crypto.com | Yes | Yes | |
+| OKX | Yes | Yes | |
+
+Refer to `docs/IMPLEMENTATION_STATUS.md` for ongoing implementation details and per-exchange notes.
+
 ## Unified Abstraction Design
 
 Advanced order types share common behaviours: splitting orders, scheduling placements and monitoring state. To encourage consistency each exchange implementation should provide an `AdvancedOrderExecutor` built on top of `ExecutionClient`:

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -414,7 +414,7 @@ paper trading:
 > **Goal:** Implement advanced execution order types for all supported exchanges and both live/paper trading: 'always maker' (post-only, top-of-book, auto-cancel/repost), and advanced TWAP/VWAP with untraceable curves using order book blending and jackbot-data analytics. Ensure robust abstraction, event handling, and test coverage.
 
 **General Steps:**
-- [ ] Research and document post-only/maker order support and limitations for all supported exchanges (spot/futures).
+ - [x] Research and document post-only/maker order support and limitations for all supported exchanges (spot/futures). See [ADVANCED_ORDER_TYPE_SUPPORT.md](ADVANCED_ORDER_TYPE_SUPPORT.md#maker-only-post-only-support).
  - [x] Design/extend a unified abstraction for advanced execution strategies (modular, composable, and testable).
  - [x] Implement 'always maker' order logic:
     - [x] Place post-only order at top of book (best bid for buy, best ask for sell).


### PR DESCRIPTION
## Summary
- add maker-only table to advanced order type documentation
- mark research step complete in implementation status

## Testing
- `cargo fmt --all -- --check` *(fails: 'cargo-fmt' not installed)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: component not installed)*
- `cargo test --workspace` *(fails to fetch crates due to network)*