### PR TITLE
Add Gate trade WS modules

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -270,6 +270,7 @@ paper trading:
 - Example files dedicated to L1 streams have also been removed.
 - Added `TRADE_WS_ENDPOINTS.md` summarising trade WebSocket endpoints.
 - Scaffolding baseline trade WebSocket modules across exchanges.
+- Implemented Gate.io trade WebSocket modules with event normalization.
 
 ## Current Features
 

--- a/jackbot-data/src/exchange/gate/futures/mod.rs
+++ b/jackbot-data/src/exchange/gate/futures/mod.rs
@@ -1,3 +1,4 @@
 //! Futures market modules for Gate.io.
 
 pub mod l2;
+pub mod trade;

--- a/jackbot-data/src/exchange/gate/futures/trade.rs
+++ b/jackbot-data/src/exchange/gate/futures/trade.rs
@@ -1,0 +1,3 @@
+//! Public trade stream types for Gate.io Futures.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/gate/mod.rs
+++ b/jackbot-data/src/exchange/gate/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod spot;
 pub mod futures;
+pub mod trade;

--- a/jackbot-data/src/exchange/gate/spot/mod.rs
+++ b/jackbot-data/src/exchange/gate/spot/mod.rs
@@ -1,3 +1,4 @@
 //! Spot market modules for Gate.io.
 
 pub mod l2;
+pub mod trade;

--- a/jackbot-data/src/exchange/gate/spot/trade.rs
+++ b/jackbot-data/src/exchange/gate/spot/trade.rs
@@ -1,0 +1,3 @@
+//! Public trade stream types for Gate.io Spot.
+
+pub use super::super::trade::*;

--- a/jackbot-data/src/exchange/gate/trade.rs
+++ b/jackbot-data/src/exchange/gate/trade.rs
@@ -1,0 +1,96 @@
+//! Trade event parsing and types for Gate.io exchange.
+
+use crate::{
+    Identifier,
+    event::{MarketEvent, MarketIter},
+    subscription::trade::PublicTrade,
+};
+use chrono::{DateTime, Utc};
+use jackbot_instrument::{Side, exchange::ExchangeId};
+use jackbot_integration::subscription::SubscriptionId;
+use serde::{Deserialize, Serialize};
+
+/// Gate.io trade message as received from the WebSocket API.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct GateTrade {
+    #[serde(alias = "currency_pair")]
+    pub market: String,
+    pub price: String,
+    pub amount: String,
+    pub side: String,
+    pub time: u64,
+    #[serde(default)]
+    pub id: String,
+}
+
+impl GateTrade {
+    pub fn to_public_trade(&self) -> Option<PublicTrade> {
+        let price = self.price.parse::<f64>().ok()?;
+        let amount = self.amount.parse::<f64>().ok()?;
+        let side = match self.side.to_ascii_lowercase().as_str() {
+            "buy" => Side::Buy,
+            "sell" => Side::Sell,
+            _ => return None,
+        };
+        Some(PublicTrade { id: self.id.clone(), price, amount, side })
+    }
+}
+
+/// Wrapper for a batch of Gate.io trades.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct GateTrades {
+    pub data: Vec<GateTrade>,
+    #[serde(skip)]
+    pub subscription_id: Option<SubscriptionId>,
+}
+
+impl Identifier<Option<SubscriptionId>> for GateTrades {
+    fn id(&self) -> Option<SubscriptionId> {
+        self.subscription_id.clone()
+    }
+}
+
+impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, GateTrades)>
+    for MarketIter<InstrumentKey, PublicTrade>
+{
+    fn from((exchange, instrument, trades): (ExchangeId, InstrumentKey, GateTrades)) -> Self {
+        trades
+            .data
+            .into_iter()
+            .filter_map(|t| t.to_public_trade())
+            .map(|public| {
+                Ok(MarketEvent {
+                    time_exchange: Utc::now(),
+                    time_received: Utc::now(),
+                    exchange,
+                    instrument: instrument.clone(),
+                    kind: public,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackbot_instrument::Side;
+
+    #[test]
+    fn test_gate_trade_to_public_trade() {
+        let json = r#"{
+            \"currency_pair\": \"BTC_USDT\",
+            \"price\": \"42000.5\",
+            \"amount\": \"0.01\",
+            \"side\": \"buy\",
+            \"time\": 1717000000000,
+            \"id\": \"abc\"
+        }"#;
+        let trade: GateTrade = serde_json::from_str(json).unwrap();
+        let public = trade.to_public_trade().unwrap();
+        assert_eq!(public.price, 42000.5);
+        assert_eq!(public.amount, 0.01);
+        assert_eq!(public.side, Side::Buy);
+        assert_eq!(public.id, "abc");
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Gate trade websocket modules
- expose spot & futures trade modules
- document Gate trade support

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt not installed)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy not installed)*
- `cargo test --workspace` *(fails: could not download crates)*