### PR TITLE
Fix snapshot scheduler tests and update docs

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -591,6 +591,9 @@ paper trading:
 - [x] MEXC: Integrate snapshot logic for order book and trades
 - [x] Gate.io: Integrate snapshot logic for order book and trades
 - [x] Crypto.com: Integrate snapshot logic for order book and trades
+- [ ] Snapshot module uses a simplified metadata file and local S3 directories
+  for testing. Full AWS credential handling and production-grade Iceberg
+  table management remain future work.
 
 **Final Steps:**
 - [ ] Update feature matrix and exchange-by-exchange status in this file.

--- a/jackbot-data/src/exchange/gate/futures/l2.rs
+++ b/jackbot-data/src/exchange/gate/futures/l2.rs
@@ -43,13 +43,13 @@ impl GateFuturesOrderBookL2 {
     /// Persist this order book snapshot to the provided [`RedisStore`].
     pub fn store_snapshot<Store: RedisStore>(&self, store: &Store) {
         let snapshot = self.canonicalize(self.time);
-        store.store_snapshot(ExchangeId::GateIo, self.subscription_id.as_ref(), &snapshot);
+        store.store_snapshot(ExchangeId::Gateio, self.subscription_id.as_ref(), &snapshot);
     }
 
     /// Persist this order book update to the provided [`RedisStore`].
     pub fn store_delta<Store: RedisStore>(&self, store: &Store) {
         let delta = OrderBookEvent::Update(self.canonicalize(self.time));
-        store.store_delta(ExchangeId::GateIo, self.subscription_id.as_ref(), &delta);
+        store.store_delta(ExchangeId::Gateio, self.subscription_id.as_ref(), &delta);
     }
 }
 
@@ -92,10 +92,10 @@ mod tests {
             asks: vec![(dec!(30010.0), dec!(2.0))],
         };
         book.store_snapshot(&store);
-        assert!(store.get_snapshot(ExchangeId::GateIo, "BTC_USDT").is_some());
+        assert!(store.get_snapshot(ExchangeId::Gateio, "BTC_USDT").is_some());
 
         let delta_book = GateFuturesOrderBookL2 { time: Utc::now(), ..book };
         delta_book.store_delta(&store);
-        assert_eq!(store.delta_len(ExchangeId::GateIo, "BTC_USDT"), 1);
+        assert_eq!(store.delta_len(ExchangeId::Gateio, "BTC_USDT"), 1);
     }
 }

--- a/jackbot-data/src/exchange/gate/spot/l2.rs
+++ b/jackbot-data/src/exchange/gate/spot/l2.rs
@@ -43,13 +43,13 @@ impl GateOrderBookL2 {
     /// Persist this order book snapshot to the provided [`RedisStore`].
     pub fn store_snapshot<Store: RedisStore>(&self, store: &Store) {
         let snapshot = self.canonicalize(self.time);
-        store.store_snapshot(ExchangeId::GateIo, self.subscription_id.as_ref(), &snapshot);
+        store.store_snapshot(ExchangeId::Gateio, self.subscription_id.as_ref(), &snapshot);
     }
 
     /// Persist this order book update to the provided [`RedisStore`].
     pub fn store_delta<Store: RedisStore>(&self, store: &Store) {
         let delta = OrderBookEvent::Update(self.canonicalize(self.time));
-        store.store_delta(ExchangeId::GateIo, self.subscription_id.as_ref(), &delta);
+        store.store_delta(ExchangeId::Gateio, self.subscription_id.as_ref(), &delta);
     }
 }
 
@@ -92,10 +92,10 @@ mod tests {
             asks: vec![(dec!(30010.0), dec!(2.0))],
         };
         book.store_snapshot(&store);
-        assert!(store.get_snapshot(ExchangeId::GateIo, "BTC_USDT").is_some());
+        assert!(store.get_snapshot(ExchangeId::Gateio, "BTC_USDT").is_some());
 
         let delta_book = GateOrderBookL2 { time: Utc::now(), ..book };
         delta_book.store_delta(&store);
-        assert_eq!(store.delta_len(ExchangeId::GateIo, "BTC_USDT"), 1);
+        assert_eq!(store.delta_len(ExchangeId::Gateio, "BTC_USDT"), 1);
     }
 }

--- a/jackbot-execution/src/client/gateio.rs
+++ b/jackbot-execution/src/client/gateio.rs
@@ -26,7 +26,7 @@ pub struct GateIoClient;
 pub struct GateIoConfig;
 
 impl ExecutionClient for GateIoClient {
-    const EXCHANGE: ExchangeId = ExchangeId::GateIo;
+    const EXCHANGE: ExchangeId = ExchangeId::Gateio;
     type Config = GateIoConfig;
     type AccountStream = stream::Empty<UnindexedAccountEvent>;
 

--- a/jackbot-instrument/src/exchange.rs
+++ b/jackbot-instrument/src/exchange.rs
@@ -57,7 +57,6 @@ pub enum ExchangeId {
     Cryptocom,
     Deribit,
     Gemini,
-    GateIo,
     Hitbtc,
     #[serde(alias = "huobi")]
     Htx,
@@ -66,7 +65,6 @@ pub enum ExchangeId {
     Liquid,
     Gateio,
     Mexc,
-    Gateio,
     Okx,
     Poloniex,
     Hyperliquid,
@@ -102,7 +100,6 @@ impl ExchangeId {
             ExchangeId::Cryptocom => "cryptocom",
             ExchangeId::Deribit => "deribit",
             ExchangeId::Gemini => "gemini",
-            ExchangeId::GateIo => "gate_io",
             ExchangeId::Hitbtc => "hitbtc",
             ExchangeId::Htx => "htx", // huobi alias
             ExchangeId::Kraken => "kraken",
@@ -110,7 +107,6 @@ impl ExchangeId {
             ExchangeId::Liquid => "liquid",
             ExchangeId::Gateio => "gateio",
             ExchangeId::Mexc => "mexc",
-            ExchangeId::Gateio => "gateio",
             ExchangeId::Okx => "okx",
             ExchangeId::Poloniex => "poloniex",
             ExchangeId::Hyperliquid => "hyperliquid",

--- a/jackbot-integration/Cargo.toml
+++ b/jackbot-integration/Cargo.toml
@@ -62,3 +62,4 @@ chrono = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 bytes = { workspace = true }
 derive_more = { workspace = true, features = ["display", "constructor"] }
+rand = { workspace = true }

--- a/jackbot-integration/src/protocol/websocket.rs
+++ b/jackbot-integration/src/protocol/websocket.rs
@@ -13,7 +13,8 @@ use tokio_tungstenite::{
     },
 };
 use tracing::{debug, warn};
-use futures::{Stream, StreamExt};
+use futures::Stream;
+use tokio_stream::StreamExt;
 use std::{time::Duration, io};
 use crate::metric::{Metric, Tag, Field};
 use chrono::Utc;

--- a/jackbot-snapshot/Cargo.toml
+++ b/jackbot-snapshot/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2024"
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "sync"] }
 chrono = { workspace = true }
 

--- a/jackbot-snapshot/src/lib.rs
+++ b/jackbot-snapshot/src/lib.rs
@@ -86,9 +86,9 @@ fn cleanup_old_files(root: &Path, retention: Duration) -> io::Result<()> {
 }
 
 #[derive(Serialize, Deserialize, Default)]
-struct IcebergMeta {
-    schema_version: u32,
-    files: Vec<String>,
+pub struct IcebergMeta {
+    pub schema_version: u32,
+    pub files: Vec<String>,
 }
 
 /// Append a new file path to the Iceberg metadata file if it is not already present.
@@ -177,7 +177,9 @@ mod tests {
         let dir = std::env::temp_dir();
         let s3_root = dir.join("s3_test");
         let meta = dir.join("meta.json");
-        let cfg = SnapshotConfig { interval: Duration::from_millis(1), retention: Duration::from_secs(0) };
+        let _ = fs::remove_dir_all(&s3_root);
+        let _ = fs::remove_file(&meta);
+        let cfg = SnapshotConfig { interval: Duration::from_millis(1), retention: Duration::from_secs(1) };
         let scheduler = SnapshotScheduler::new(redis, s3_root.clone(), meta.clone(), cfg);
         scheduler.snapshot_once().await.unwrap();
         assert!(fs::read_dir(s3_root.join("exch/btc-usd")).unwrap().next().is_some());
@@ -192,7 +194,9 @@ mod tests {
         let dir = std::env::temp_dir();
         let s3_root = dir.join("s3_empty");
         let meta = dir.join("meta_empty.json");
-        let cfg = SnapshotConfig { interval: Duration::from_millis(1), retention: Duration::from_secs(0) };
+        let _ = fs::remove_dir_all(&s3_root);
+        let _ = fs::remove_file(&meta);
+        let cfg = SnapshotConfig { interval: Duration::from_millis(1), retention: Duration::from_secs(1) };
         let scheduler = SnapshotScheduler::new(redis, s3_root.clone(), meta.clone(), cfg);
         scheduler.snapshot_once().await.unwrap();
         assert!(!s3_root.exists());

--- a/jackbot-snapshot/tests/integration.rs
+++ b/jackbot-snapshot/tests/integration.rs
@@ -15,10 +15,13 @@ async fn test_scheduler_multiple_snapshots() {
     let dir = std::env::temp_dir();
     let s3_root = dir.join("s3_integration");
     let meta = dir.join("meta_integration.json");
-    let cfg = SnapshotConfig { interval: Duration::from_millis(1), retention: Duration::from_secs(0) };
+    let _ = std::fs::remove_dir_all(&s3_root);
+    let _ = std::fs::remove_file(&meta);
+    let cfg = SnapshotConfig { interval: Duration::from_millis(1), retention: Duration::from_secs(1) };
     let scheduler = SnapshotScheduler::new(redis, s3_root.clone(), meta.clone(), cfg);
     // Take two snapshots manually
     scheduler.snapshot_once().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(1)).await;
     scheduler.snapshot_once().await.unwrap();
 
     let files: Vec<_> = std::fs::read_dir(s3_root.join("exch/eth-usd")).unwrap().collect();


### PR DESCRIPTION
## Summary
- deduplicate Gateio exchange enum
- ensure Gateio usage is consistent across crates
- fix websocket heartbeat import
- add missing `rand` dependency
- tweak snapshot tests to use retention and cleanup
- expose `IcebergMeta` struct for tests
- add note on snapshot module limitations

## Testing
- `cargo test -p jackbot-snapshot -- --test-threads=1`