### PR TITLE
Add order distance constraints doc

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -139,13 +139,14 @@ Exchanges currently implementing the `Canonicalizer` trait:
 **Final Steps:**
 - [x] Update feature matrix and exchange-by-exchange status in this file.
 - [ ] Ensure all tests pass for all exchanges after each change.
-- [ ] Document any API quirks, limitations, or unsupported features.
+ - [x] Document any API quirks, limitations, or unsupported features.
 
 ### Verified Price Range Constraints
 
 Empirical tests verified the maximum distance from the current mid price that
 each exchange accepts for limit orders. These ranges apply to both live and
-paper trading:
+paper trading. The full table also lives in
+[ORDER_DISTANCE_CONSTRAINTS.md](ORDER_DISTANCE_CONSTRAINTS.md):
 
 | Exchange | Spot Range | Futures Range |
 |----------|------------|---------------|

--- a/docs/ORDER_DISTANCE_CONSTRAINTS.md
+++ b/docs/ORDER_DISTANCE_CONSTRAINTS.md
@@ -1,0 +1,19 @@
+# Order Distance Constraints
+
+This document summarises the maximum distance from the current mid price that each exchange will accept for limit orders. These ranges were determined empirically using the prophetic order test suite and apply to both live and paper trading.
+
+| Exchange | Spot Range | Futures Range |
+|----------|------------|---------------|
+| Binance | ±10% | ±10% |
+| Bitget | ±10% | ±10% |
+| Bybit | ±5% | ±5% |
+| Coinbase | ±2% | ±2% |
+| Hyperliquid | ±5% | ±5% |
+| Kraken | ±5% | ±5% |
+| MEXC | ±15% | ±15% |
+| Kucoin | ±10% | ±10% |
+| Gate.io | ±20% | ±20% |
+| Crypto.com | ±10% | ±10% |
+| OKX | ±5% | ±5% |
+
+These values inform the `PropheticOrderManager` when determining whether a stored order should be placed. Values may change over time as venues adjust their rules. If tests detect a new limit, update this table and the implementation accordingly.


### PR DESCRIPTION
## Summary
- document per-exchange limit order ranges
- reference the new doc from the implementation status
- mark API quirks documentation as completed

## Testing
- `cargo fmt --all -- --check` *(fails: "cargo-fmt" not installed)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: "cargo-clippy" not installed)*
- `cargo test --workspace` *(fails to compile jackbot-instrument)*