### PR TITLE
Expand execution docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Cargo.lock
 # IDE
 .idea/
 *.iml
+/vendor/
+/.cargo/

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -296,8 +296,8 @@ paper trading:
 - [x] Implement or refactor exchange adapters for live trading (real orders via authenticated API/WebSocket).
 - [x] Implement a robust paper trading engine (simulated fills, order book emulation, event emission, etc.).
 - [x] Add/extend integration tests for both live and paper trading (with mocks/sandboxes where possible).
-- [ ] Add/extend module-level and user-facing documentation.
-- [ ] Update `docs/IMPLEMENTATION_STATUS.md` with status and links.
+- [x] Add/extend module-level and user-facing documentation.
+- [x] Update `docs/IMPLEMENTATION_STATUS.md` with status and links.
 
 **Exchange-Specific TODOs:**
 

--- a/jackbot-execution/README.md
+++ b/jackbot-execution/README.md
@@ -9,5 +9,19 @@ a feature rich MockExchange and MockExecutionClient to assist with backtesting a
 
 ## Overview
 High-performance and normalised trading interface capable of executing across many financial venues. Also provides
-a feature rich simulated exchange to assist with backtesting and dry-trading. Communicate with an exchange by 
-initialising it's associated `ExecutionClient` instance. 
+a feature rich simulated exchange to assist with backtesting and dry-trading. Communicate with an exchange by
+initialising it's associated `ExecutionClient` instance.
+
+## Live vs. Paper Trading
+
+Jackbot-Execution exposes the same `ExecutionClient` trait for both modes.
+
+- **Live trading** clients connect to real exchange APIs and place actual
+  orders. Account updates stream directly from the venue.
+- **Paper trading** uses the in-memory `PaperEngine` and associated clients
+  (for example `BinancePaperClient`) to simulate fills using order book
+  snapshots. This is ideal for dry runs or integration testing without
+  risking capital.
+
+Switch between modes by selecting the appropriate client implementation in your
+strategy configuration.

--- a/jackbot-execution/src/client/binance/paper.rs
+++ b/jackbot-execution/src/client/binance/paper.rs
@@ -1,3 +1,9 @@
+//! Binance paper trading client.
+//!
+//! `BinancePaperClient` wraps [`PaperEngine`] to emulate Binance Spot trading
+//! while exposing the [`ExecutionClient`] interface. This allows switching
+//! between live and paper modes by swapping the client implementation in a
+//! strategy's configuration.
 use crate::{
     client::ExecutionClient,
     exchange::paper::{PaperBook, PaperEngine},

--- a/jackbot-execution/src/exchange/paper.rs
+++ b/jackbot-execution/src/exchange/paper.rs
@@ -1,3 +1,9 @@
+//! Simulated exchange engine used for paper trading.
+//!
+//! [`PaperEngine`] tracks balances, open orders and trade fills using provided
+//! [`PaperBook`] order books. It exposes the same behavior as a real
+//! [`ExecutionClient`], allowing strategies to evaluate performance without
+//! interacting with live venues.
 use crate::{
     exchange::mock::account::AccountState,
     exchange::mock::OpenOrderNotifications,

--- a/jackbot-execution/src/lib.rs
+++ b/jackbot-execution/src/lib.rs
@@ -22,6 +22,20 @@
 //! * **Extensible**: Jackbot-Execution is highly extensible, making it easy to contribute by adding new exchange integrations!
 //!
 //! See `README.md` for more information and examples.
+//!
+//! ## Trading Modes
+//!
+//! Jackbot-Execution supports two runtime modes:
+//! - **Live**: orders are submitted to real exchanges using an
+//!   [`ExecutionClient`] implementation. Account snapshots and updates stream
+//!   directly from the venue APIs.
+//! - **Paper**: orders are routed through the in-memory [`exchange::paper`]
+//!   engine which simulates fills via [`PaperBook`] order books. This mode
+//!   mirrors the live API and is ideal for dry-runs or strategy development
+//!   without placing real trades.
+//!
+//! Both modes expose the same trait interfaces, allowing strategies to switch
+//! between live and paper with only configuration changes.
 
 use crate::{
     balance::AssetBalance,


### PR DESCRIPTION
## Summary
- document live vs. paper trading in jackbot-execution
- note trading modes in README
- record doc completion in IMPLEMENTATION_STATUS
- ignore vendored sources

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt missing)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy missing)*
- `cargo test --workspace` *(fails: could not compile dependencies)*
