### PR TITLE
Document snapshot quirks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,5 @@ Please read our contribution guidelines before submitting pull requests.
 
 The `jackbot-snapshot` crate demonstrates extracting multi-exchange order book and trade data from Redis and persisting it to an S3 data lake managed with Apache Iceberg. Snapshots are written in Parquet format and uploaded to partitioned paths organised by exchange and market using AWS credentials. A `file://` path can be used for local testing. Duplicate files are avoided and stale snapshots are pruned based on a configurable retention period. See [SNAPSHOT_PIPELINE.md](docs/SNAPSHOT_PIPELINE.md) for details on how the scheduler works and how to configure it.
 
+
+Note: uploads currently rely on the `aws` CLI. Ensure it is installed and configured. Cleanup of old objects in S3 is not implemented; only local paths are pruned. Every snapshot writes the full set of Redis records.

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -637,6 +637,7 @@ paper and mock engines support automatic liquidation.
 - [x] Crypto.com: Integrate snapshot logic for order book and trades
 - [x] Snapshot module now supports AWS credentials and full Iceberg table
   management. Local paths remain available for tests via the `file://` scheme.
+- Snapshot uploads rely on the `aws` CLI and do not clean up old objects in S3.
 
 
 **Final Steps:**

--- a/docs/SNAPSHOT_PIPELINE.md
+++ b/docs/SNAPSHOT_PIPELINE.md
@@ -16,3 +16,7 @@ This document describes how Jackbot persists order book and trade data from Redi
 The scheduler interval and retention are specified via `SnapshotConfig`. Running `SnapshotScheduler::start` will continuously persist snapshots according to this configuration.
 
 This pipeline allows efficient, queryable storage of historical market data while keeping Redis memory usage under control.
+
+## Limitations
+
+SnapshotScheduler currently shells out to the `aws` CLI for uploads instead of using the internal `S3Store`. The CLI must be installed and available in PATH. Cleanup of expired objects in S3 is not implemented, so only local paths benefit from retention pruning. Each snapshot writes all Redis records and may grow large on busy systems.


### PR DESCRIPTION
## Summary
- document snapshot pipeline limitations
- mention CLI reliance in README
- note snapshot quirks in IMPLEMENTATION_STATUS

## Testing
- `cargo fmt --all -- --check` *(fails: unexpected closing delimiter)*