### PR TITLE
Fix snapshot-to-S3 tests

### DIFF
--- a/jackbot-snapshot/tests/integration.rs
+++ b/jackbot-snapshot/tests/integration.rs
@@ -26,7 +26,8 @@ async fn test_scheduler_multiple_snapshots() {
         interval: Duration::from_millis(1),
         retention: Duration::from_secs(1),
     };
-    let scheduler = SnapshotScheduler::new(redis, s3_root.clone(), meta.clone(), cfg);
+    let store = Arc::new(LocalStore::new(local_root.to_path_buf()));
+    let scheduler = SnapshotScheduler::new(redis, s3_root.clone(), store, meta.clone(), cfg);
 
     // Take two snapshots manually
     scheduler.snapshot_once().await.unwrap();


### PR DESCRIPTION
## Summary
- clean up snapshot code for LocalStore cleanup
- add timestamp/id when registering S3 snapshot
- rename upload helper used by S3Store
- update tests to pass object store into scheduler

## Testing
- `rustfmt --check jackbot-snapshot/src/lib.rs jackbot-snapshot/tests/integration.rs`
- `cargo test -p jackbot-snapshot`
- `cargo test --workspace` *(fails: could not compile `jackbot-data`)*