### PR TITLE
Fix Redis data tests

### DIFF
--- a/jackbot-data/src/exchange/gateio/futures/l2.rs
+++ b/jackbot-data/src/exchange/gateio/futures/l2.rs
@@ -42,13 +42,13 @@ impl GateioFuturesOrderBookL2 {
     /// Persist this order book snapshot to the provided [`RedisStore`].
     pub fn store_snapshot<Store: RedisStore>(&self, store: &Store) {
         let snapshot = self.canonicalize(self.time);
-        store.store_snapshot(ExchangeId::GateIo, self.subscription_id.as_ref(), &snapshot);
+        store.store_snapshot(ExchangeId::Gateio, self.subscription_id.as_ref(), &snapshot);
     }
 
     /// Persist this order book update to the provided [`RedisStore`].
     pub fn store_delta<Store: RedisStore>(&self, store: &Store) {
         let delta = OrderBookEvent::Update(self.canonicalize(self.time));
-        store.store_delta(ExchangeId::GateIo, self.subscription_id.as_ref(), &delta);
+        store.store_delta(ExchangeId::Gateio, self.subscription_id.as_ref(), &delta);
     }
 }
 

--- a/jackbot-data/src/exchange/gateio/spot/l2.rs
+++ b/jackbot-data/src/exchange/gateio/spot/l2.rs
@@ -41,20 +41,22 @@ impl GateioOrderBookL2 {
     /// Persist this order book snapshot to the provided [`RedisStore`].
     pub fn store_snapshot<Store: RedisStore>(&self, store: &Store) {
         let snapshot = self.canonicalize(self.time);
-        store.store_snapshot(ExchangeId::GateIo, self.subscription_id.as_ref(), &snapshot);
+        store.store_snapshot(ExchangeId::Gateio, self.subscription_id.as_ref(), &snapshot);
     }
 
     /// Persist this order book update to the provided [`RedisStore`].
     pub fn store_delta<Store: RedisStore>(&self, store: &Store) {
         let delta = OrderBookEvent::Update(self.canonicalize(self.time));
-        store.store_delta(ExchangeId::GateIo, self.subscription_id.as_ref(), &delta);
+        store.store_delta(ExchangeId::Gateio, self.subscription_id.as_ref(), &delta);
     }
 }
 
 impl<InstrumentKey> From<(ExchangeId, InstrumentKey, GateioOrderBookL2)>
     for MarketIter<InstrumentKey, OrderBookEvent>
 {
-    fn from((exchange_id, instrument, book): (ExchangeId, InstrumentKey, GateioOrderBookL2)) -> Self {
+    fn from(
+        (exchange_id, instrument, book): (ExchangeId, InstrumentKey, GateioOrderBookL2),
+    ) -> Self {
         let order_book = book.canonicalize(book.time);
 
         Self(vec![Ok(MarketEvent {

--- a/jackbot-data/src/exchange/hyperliquid/futures/trade.rs
+++ b/jackbot-data/src/exchange/hyperliquid/futures/trade.rs
@@ -1,14 +1,13 @@
 //! Trade event types for Hyperliquid Futures.
 //!
-//! Provides convenient aliases for [`Hyperliquid`](super::super::super::Hyperliquid)
+//! Provides convenient aliases for [`Hyperliquid`](super::super::Hyperliquid)
 //! futures trade streams.
 
+use super::super::Hyperliquid;
 use crate::{
+    ExchangeWsStream, subscription::trade::PublicTrades,
     transformer::stateless::StatelessTransformer,
-    subscription::trade::PublicTrades,
-    ExchangeWsStream,
 };
-use super::super::super::Hyperliquid;
 
 pub use super::super::trade::HyperliquidTrades;
 

--- a/jackbot-data/src/exchange/hyperliquid/spot/trade.rs
+++ b/jackbot-data/src/exchange/hyperliquid/spot/trade.rs
@@ -1,14 +1,13 @@
 //! Trade event types for Hyperliquid Spot.
 //!
-//! Provides convenient aliases for [`Hyperliquid`](super::super::super::Hyperliquid)
+//! Provides convenient aliases for [`Hyperliquid`](super::super::Hyperliquid)
 //! trade streams.
 
+use super::super::Hyperliquid;
 use crate::{
+    ExchangeWsStream, subscription::trade::PublicTrades,
     transformer::stateless::StatelessTransformer,
-    subscription::trade::PublicTrades,
-    ExchangeWsStream,
 };
-use super::super::super::Hyperliquid;
 
 pub use super::super::trade::HyperliquidTrades;
 

--- a/jackbot-data/src/streams/consumer.rs
+++ b/jackbot-data/src/streams/consumer.rs
@@ -12,9 +12,9 @@ use crate::{
     },
     subscription::{Subscription, SubscriptionKind, display_subscriptions_without_exchange},
 };
-use jackbot_instrument::exchange::ExchangeId;
 use derive_more::Constructor;
-use futures::Stream;
+use futures::{Stream, StreamExt};
+use jackbot_instrument::exchange::ExchangeId;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use tracing::info;
@@ -70,7 +70,10 @@ where
         "MarketStream with auto reconnect initialising"
     );
 
-    use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
     use tokio::time::Instant;
 
     let reconnects = Arc::new(AtomicUsize::new(0));

--- a/jackbot-data/tests/redis_integration.rs
+++ b/jackbot-data/tests/redis_integration.rs
@@ -1,17 +1,17 @@
+use chrono::Utc;
+use futures::Stream;
 use jackbot_data::{
+    Identifier,
     books::{manager::OrderBookL2Manager, map::OrderBookMap},
     redis_store::InMemoryStore,
-    subscription::book::OrderBookEvent,
     streams::consumer::MarketStreamEvent,
-    Identifier,
+    subscription::book::OrderBookEvent,
 };
 use jackbot_instrument::{
     exchange::ExchangeId,
     instrument::market_data::{MarketDataInstrument, kind::MarketDataInstrumentKind},
 };
 use rust_decimal_macros::dec;
-use chrono::Utc;
-use futures::Stream;
 use tokio_stream::StreamExt;
 
 #[tokio::test]
@@ -38,16 +38,32 @@ async fn test_store_snapshot_and_delta() {
     let stream = futures::stream::iter(events);
 
     let mut map = jackbot_data::books::map::OrderBookMapMulti::new(Default::default());
-    map.insert(instrument.clone(), std::sync::Arc::new(parking_lot::RwLock::new(jackbot_data::books::OrderBook::default())));
+    map.insert(
+        instrument.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(
+            jackbot_data::books::OrderBook::default(),
+        )),
+    );
 
     let store = InMemoryStore::new();
 
-    let manager = OrderBookL2Manager { stream, books: map, store: store.clone() };
+    let manager = OrderBookL2Manager {
+        stream,
+        books: map,
+        store: store.clone(),
+    };
 
     manager.run().await;
 
-    assert!(store.get_snapshot_json(ExchangeId::BinanceSpot, &instrument.to_string()).is_some());
-    assert_eq!(store.delta_len(ExchangeId::BinanceSpot, &instrument.to_string()), 1);
+    assert!(
+        store
+            .get_snapshot_json(ExchangeId::BinanceSpot, &instrument.to_string())
+            .is_some()
+    );
+    assert_eq!(
+        store.delta_len(ExchangeId::BinanceSpot, &instrument.to_string()),
+        1
+    );
 }
 
 #[tokio::test]
@@ -81,22 +97,38 @@ async fn test_reconnect_overwrites_snapshot() {
     let stream = futures::stream::iter(events);
 
     let mut map = jackbot_data::books::map::OrderBookMapMulti::new(Default::default());
-    map.insert(instrument.clone(), std::sync::Arc::new(parking_lot::RwLock::new(jackbot_data::books::OrderBook::default())));
+    map.insert(
+        instrument.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(
+            jackbot_data::books::OrderBook::default(),
+        )),
+    );
 
     let store = InMemoryStore::new();
 
-    let manager = OrderBookL2Manager { stream, books: map, store: store.clone() };
+    let manager = OrderBookL2Manager {
+        stream,
+        books: map,
+        store: store.clone(),
+    };
 
     manager.run().await;
 
-    assert!(store.get_snapshot_json(ExchangeId::BinanceSpot, &instrument.to_string()).is_some());
-    assert_eq!(store.delta_len(ExchangeId::BinanceSpot, &instrument.to_string()), 1);
+    assert!(
+        store
+            .get_snapshot_json(ExchangeId::BinanceSpot, &instrument.to_string())
+            .is_some()
+    );
+    assert_eq!(
+        store.delta_len(ExchangeId::BinanceSpot, &instrument.to_string()),
+        1
+    );
 }
 
 #[test]
 fn test_mexc_store_methods() {
-    use jackbot_data::exchange::mexc::spot::l2::MexcOrderBookL2;
     use jackbot_data::exchange::mexc::futures::l2::MexcFuturesOrderBookL2;
+    use jackbot_data::exchange::mexc::spot::l2::MexcOrderBookL2;
 
     let store = InMemoryStore::new();
 
@@ -107,9 +139,16 @@ fn test_mexc_store_methods() {
         asks: vec![(dec!(30010.0), dec!(2.0))],
     };
     spot_book.store_snapshot(&store);
-    assert!(store.get_snapshot_json(ExchangeId::Mexc, "BTC_USDT").is_some());
+    assert!(
+        store
+            .get_snapshot_json(ExchangeId::Mexc, "BTC_USDT")
+            .is_some()
+    );
 
-    let delta_book = MexcOrderBookL2 { time: Utc::now(), ..spot_book };
+    let delta_book = MexcOrderBookL2 {
+        time: Utc::now(),
+        ..spot_book
+    };
     delta_book.store_delta(&store);
     assert_eq!(store.delta_len(ExchangeId::Mexc, "BTC_USDT"), 1);
 
@@ -122,15 +161,18 @@ fn test_mexc_store_methods() {
     fut_book.store_snapshot(&store);
     fut_book.store_delta(&store);
 
-    assert!(store.get_snapshot_json(ExchangeId::Mexc, "BTC_USDT").is_some());
+    assert!(
+        store
+            .get_snapshot_json(ExchangeId::Mexc, "BTC_USDT")
+            .is_some()
+    );
     assert_eq!(store.delta_len(ExchangeId::Mexc, "BTC_USDT"), 2);
 }
 
 #[test]
 
-
 fn test_query_methods() {
-    use jackbot_data::books::{OrderBook, Level};
+    use jackbot_data::books::{Level, OrderBook};
     use jackbot_data::subscription::book::OrderBookEvent;
 
     let store = InMemoryStore::new();
@@ -138,18 +180,39 @@ fn test_query_methods() {
     store.store_snapshot(ExchangeId::BinanceSpot, "BTC_USDT", &snapshot);
     let delta = OrderBookEvent::Update(OrderBook::new(0, None, [], []));
     store.store_delta(ExchangeId::BinanceSpot, "BTC_USDT", &delta);
-    store.store_trade(ExchangeId::BinanceSpot, "BTC_USDT", &jackbot_data::subscription::trade::PublicTrade {
-        id: "1".into(), price: 1.0, amount: 1.0, side: jackbot_instrument::Side::Buy });
+    store.store_trade(
+        ExchangeId::BinanceSpot,
+        "BTC_USDT",
+        &jackbot_data::subscription::trade::PublicTrade {
+            id: "1".into(),
+            price: 1.0,
+            amount: 1.0,
+            side: jackbot_instrument::Side::Buy,
+        },
+    );
 
-    assert!(store.get_snapshot(ExchangeId::BinanceSpot, "BTC_USDT").is_some());
-    assert_eq!(store.get_deltas(ExchangeId::BinanceSpot, "BTC_USDT", 1).len(), 1);
-    assert_eq!(store.get_trades(ExchangeId::BinanceSpot, "BTC_USDT", 1).len(), 1);
+    assert!(
+        store
+            .get_snapshot(ExchangeId::BinanceSpot, "BTC_USDT")
+            .is_some()
+    );
+    assert_eq!(
+        store
+            .get_deltas(ExchangeId::BinanceSpot, "BTC_USDT", 1)
+            .len(),
+        1
+    );
+    assert_eq!(
+        store
+            .get_trades(ExchangeId::BinanceSpot, "BTC_USDT", 1)
+            .len(),
+        1
+    );
 }
 
-
 fn test_cryptocom_store_methods() {
-    use jackbot_data::exchange::cryptocom::spot::l2::CryptocomOrderBookL2;
     use jackbot_data::exchange::cryptocom::futures::l2::CryptocomFuturesOrderBookL2;
+    use jackbot_data::exchange::cryptocom::spot::l2::CryptocomOrderBookL2;
 
     let store = InMemoryStore::new();
 
@@ -160,9 +223,16 @@ fn test_cryptocom_store_methods() {
         asks: vec![(dec!(30010.0), dec!(2.0))],
     };
     spot_book.store_snapshot(&store);
-    assert!(store.get_snapshot(ExchangeId::Cryptocom, "BTC_USDT").is_some());
+    assert!(
+        store
+            .get_snapshot(ExchangeId::Cryptocom, "BTC_USDT")
+            .is_some()
+    );
 
-    let delta_book = CryptocomOrderBookL2 { time: Utc::now(), ..spot_book };
+    let delta_book = CryptocomOrderBookL2 {
+        time: Utc::now(),
+        ..spot_book
+    };
     delta_book.store_delta(&store);
     assert_eq!(store.delta_len(ExchangeId::Cryptocom, "BTC_USDT"), 1);
 
@@ -175,14 +245,18 @@ fn test_cryptocom_store_methods() {
     fut_book.store_snapshot(&store);
     fut_book.store_delta(&store);
 
-    assert!(store.get_snapshot(ExchangeId::Cryptocom, "BTC_USDT").is_some());
+    assert!(
+        store
+            .get_snapshot(ExchangeId::Cryptocom, "BTC_USDT")
+            .is_some()
+    );
     assert_eq!(store.delta_len(ExchangeId::Cryptocom, "BTC_USDT"), 2);
 }
 
 #[test]
 fn test_gateio_store_methods() {
-    use jackbot_data::exchange::gateio::spot::l2::GateioOrderBookL2;
     use jackbot_data::exchange::gateio::futures::l2::GateioFuturesOrderBookL2;
+    use jackbot_data::exchange::gateio::spot::l2::GateioOrderBookL2;
 
     let store = InMemoryStore::new();
 
@@ -193,11 +267,14 @@ fn test_gateio_store_methods() {
         asks: vec![(dec!(30010.0), dec!(2.0))],
     };
     spot_book.store_snapshot(&store);
-    assert!(store.get_snapshot(ExchangeId::GateIo, "BTC_USDT").is_some());
+    assert!(store.get_snapshot(ExchangeId::Gateio, "BTC_USDT").is_some());
 
-    let delta_book = GateioOrderBookL2 { time: Utc::now(), ..spot_book };
+    let delta_book = GateioOrderBookL2 {
+        time: Utc::now(),
+        ..spot_book
+    };
     delta_book.store_delta(&store);
-    assert_eq!(store.delta_len(ExchangeId::GateIo, "BTC_USDT"), 1);
+    assert_eq!(store.delta_len(ExchangeId::Gateio, "BTC_USDT"), 1);
 
     let fut_book = GateioFuturesOrderBookL2 {
         subscription_id: "BTC_USDT".into(),
@@ -208,8 +285,8 @@ fn test_gateio_store_methods() {
     fut_book.store_snapshot(&store);
     fut_book.store_delta(&store);
 
-    assert!(store.get_snapshot(ExchangeId::GateIo, "BTC_USDT").is_some());
-    assert_eq!(store.delta_len(ExchangeId::GateIo, "BTC_USDT"), 2);
+    assert!(store.get_snapshot(ExchangeId::Gateio, "BTC_USDT").is_some());
+    assert_eq!(store.delta_len(ExchangeId::Gateio, "BTC_USDT"), 2);
 }
 
 #[test]
@@ -219,16 +296,31 @@ fn test_list_trimming() {
 
     let store = InMemoryStore::new();
     for _ in 0..(jackbot_data::redis_store::MAX_LIST_LEN + 10) {
-        store.store_delta(ExchangeId::BinanceSpot, "BTC_USDT", &OrderBookEvent::Update(OrderBook::default()));
-        store.store_trade(ExchangeId::BinanceSpot, "BTC_USDT", &jackbot_data::subscription::trade::PublicTrade {
-            id: "1".into(),
-            price: 1.0,
-            amount: 1.0,
-            side: jackbot_instrument::Side::Buy,
-        });
+        store.store_delta(
+            ExchangeId::BinanceSpot,
+            "BTC_USDT",
+            &OrderBookEvent::Update(OrderBook::default()),
+        );
+        store.store_trade(
+            ExchangeId::BinanceSpot,
+            "BTC_USDT",
+            &jackbot_data::subscription::trade::PublicTrade {
+                id: "1".into(),
+                price: 1.0,
+                amount: 1.0,
+                side: jackbot_instrument::Side::Buy,
+            },
+        );
     }
 
-    assert_eq!(store.delta_len(ExchangeId::BinanceSpot, "BTC_USDT"), jackbot_data::redis_store::MAX_LIST_LEN);
-    assert_eq!(store.get_trades(ExchangeId::BinanceSpot, "BTC_USDT", usize::MAX).len(), jackbot_data::redis_store::MAX_LIST_LEN);
+    assert_eq!(
+        store.delta_len(ExchangeId::BinanceSpot, "BTC_USDT"),
+        jackbot_data::redis_store::MAX_LIST_LEN
+    );
+    assert_eq!(
+        store
+            .get_trades(ExchangeId::BinanceSpot, "BTC_USDT", usize::MAX)
+            .len(),
+        jackbot_data::redis_store::MAX_LIST_LEN
+    );
 }
-

--- a/jackbot-instrument/src/exchange.rs
+++ b/jackbot-instrument/src/exchange.rs
@@ -60,6 +60,7 @@ pub enum ExchangeId {
     Hitbtc,
     #[serde(alias = "huobi")]
     Htx,
+    Gateio,
     Kraken,
     Kucoin,
     Liquid,
@@ -104,6 +105,7 @@ impl ExchangeId {
             ExchangeId::Kraken => "kraken",
             ExchangeId::Kucoin => "kucoin",
             ExchangeId::Liquid => "liquid",
+            ExchangeId::Gateio => "gateio",
             ExchangeId::Mexc => "mexc",
             ExchangeId::Okx => "okx",
             ExchangeId::Poloniex => "poloniex",
@@ -128,7 +130,7 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_str::<ExchangeId>(r#""gateio""#).unwrap(),
-            ExchangeId::GateIo
+            ExchangeId::Gateio
         );
     }
 }


### PR DESCRIPTION
## Summary
- add `Gateio` exchange ID
- update Redis integration tests for new variant
- fix `store_delta` type mismatch
- adjust imports for compilation

## Testing
- `cargo clippy -p jackbot-data --all-targets -- -A warnings` *(fails: cannot find type `PingInterval`)*
