### PR TITLE
Document prophetic order quirks

### DIFF
--- a/docs/ADVANCED_ORDER_TYPE_SUPPORT.md
+++ b/docs/ADVANCED_ORDER_TYPE_SUPPORT.md
@@ -34,6 +34,10 @@ All exchanges expose the same trait-based interface in `jackbot-execution`. Stub
 - Coinbase only supports spot trading. Advanced orders operate on spot markets only.
 - Hyperliquid offers perpetual futures exclusively.
 - Gate.io, Crypto.com and MEXC clients are currently stubs with placeholder implementations.
+- `PropheticOrderManager` treats `range_percent` as an absolute value. Negative
+  inputs behave the same as positive ones.
+- Prophetic orders with duplicate client order IDs are ignored to prevent
+  accidental double placement.
 
 ## Maker-Only (Post-Only) Support
 

--- a/docs/ORDER_DISTANCE_CONSTRAINTS.md
+++ b/docs/ORDER_DISTANCE_CONSTRAINTS.md
@@ -17,3 +17,12 @@ This document summarises the maximum distance from the current mid price that ea
 | OKX | ±5% | ±5% |
 
 These values inform the `PropheticOrderManager` when determining whether a stored order should be placed. Values may change over time as venues adjust their rules. If tests detect a new limit, update this table and the implementation accordingly.
+
+## Testing Notes
+
+During the prophetic order tests a few quirks were identified:
+
+- A negative `range_percent` is treated the same as a positive value.
+- Orders with duplicate client IDs are ignored by the manager.
+
+Keep these behaviours in mind when integrating prophetic order logic.


### PR DESCRIPTION
## Summary
- document prophetic order quirks in docs
- mention quirks in PropheticOrderManager docs

## Testing
- `rustfmt --config skip_children=true --check jackbot/src/engine/state/order/prophetic.rs`